### PR TITLE
fix: data geometry bugs — ChanelRand overflow, Infinity guards, order:0, single-segment arc, negative values

### DIFF
--- a/docs/maintenance/08-data-geometry-fixes.md
+++ b/docs/maintenance/08-data-geometry-fixes.md
@@ -1,0 +1,234 @@
+# Stage 08 — Data geometry bug fixes
+
+## Summary
+
+- Fixed 5 confirmed bugs in data validation and geometry calculation code.
+- All fixes are covered by new tests (10 new tests in 5 files), written before
+  the fixes were applied (red → green, in order).
+- Test count: 57/160 → 57/170 (+10).
+- `pnpm run check:all` passes end-to-end.
+- No public API changes.
+- No changes to CSS, SVG output structure (only values corrected).
+- Kept CI and publish disabled.
+
+---
+
+## Bugs fixed
+
+### Bug 1: `ChanelRand` could return 256, producing wrong random colours
+
+**File:** `src/utils/color.ts`
+
+**Before:**
+```ts
+const ChanelRand = (): number => Math.floor(Math.random() * (256 + 1));
+```
+
+**After:**
+```ts
+const ChanelRand = (): number => Math.floor(Math.random() * 256);
+```
+
+**Why it's a bug:** `Math.random()` returns values in `[0, 1)` — the upper
+bound is exclusive. `Math.floor(Math.random() * 257)` can evaluate to 256 when
+`Math.random()` returns a value like `0.999999` (`Math.floor(0.999999 × 257) =
+Math.floor(256.999…) = 256`). An RGB channel value of 256 is outside the valid
+`[0, 255]` range. When it is passed to `rgbToHex`'s bitwise operation
+`(1 << 24) + (256 << 16) + (256 << 8) + 256`, each overflowing channel
+contributes an extra carry bit that corrupts the other channels, producing a
+wrong colour hex string (e.g. `#010100` instead of `#ffffff`). The string still
+passes the hex regex (correct length), so this was silent and hard to detect.
+
+**Fix:** Using multiplier `256` ensures `Math.floor(x * 256)` ≤ 255 for all
+`x ∈ [0, 1)`.
+
+**Test:** `color.spec.ts` — mocks `Math.random` to return `0.999999` and
+asserts that the result equals `'#ffffff'`. With the old formula the result was
+`'#010100'` (wrong colour due to bitwise channel overflow).
+
+---
+
+### Bug 2: `sanitizeNumber` silently passed `Infinity` and `-Infinity`
+
+**File:** `src/utils/sanitizeNumber.ts`
+
+**Before:**
+```ts
+if (isNaN(n)) { ... return defaultNumber; }
+return n;
+```
+
+**After:**
+```ts
+if (isNaN(n) || !isFinite(n)) { ... return defaultNumber; }
+return n;
+```
+
+**Why it's a bug:** `isNaN(Infinity)` is `false`, so `sanitizeNumber(Infinity)`
+returned `Infinity`. `sanitizeNumber` is the entry-point validator for numeric
+props like `donutThickness`, `gap`, `fontSize`, `hoverScaleRatio`, etc. Any
+`Infinity` that reached the geometry pipeline would produce `NaN` coordinates
+in SVG path commands (`Infinity * cos(…) = NaN`), resulting in invisible or
+broken chart segments.
+
+**Tests:** `sanitizeNumber.spec.ts` — two new tests:
+- `Infinity` → returns the provided `defaultNumber`, `consoleError` called once
+- `-Infinity` → returns `DEFAULT_SANITISE_NUMBER_VALUE`, `consoleError` called once
+
+---
+
+### Bug 3: `checkIncomingValues` did not reject `Infinity` in segment values
+
+**File:** `src/utils/createChartSegmentPathDraw/_utils/checkIncomingValues.ts`
+
+**Before:** `isNaN(valueSegment) || isNaN(valueSegmentsTotal) || ...`
+
+**After:** Added `!isFinite(valueSegment) || !isFinite(valueSegmentsPreviousTotal) || !isFinite(valueSegmentsTotal) || ...`
+
+**Why it's a bug:** `isNaN(Infinity)` is `false`, so `Infinity` values passed
+the existing guard and were forwarded to the trigonometry in
+`createSvgCommandsString`. A segment angle computed as `360 * (Infinity /
+(total || 1))` gives `Infinity`, which then produces `NaN` from
+`Math.cos(Infinity * π / 180)` — generating `NaN NaN` tokens in the SVG path
+`d` attribute.
+
+**Tests:** `checkIncomingValues.spec.ts` — two new tests:
+- `valueSegment: Infinity` → returns `false`, `consoleError` called once
+- `valueSegmentsTotal: Infinity` → returns `false`, `consoleError` called once
+
+---
+
+### Bug 4: Single-segment chart (100% = 360°) produced invisible / broken arc
+
+**File:** `src/utils/createChartSegmentPathDraw/_utils/createSvgCommandsString.ts`
+
+**Before:**
+```ts
+const { angleDegrees, ... } = props;
+```
+
+**After:**
+```ts
+const angleDegrees = Math.min(props.angleDegrees, 359.9999);
+```
+
+**Why it's a bug:** SVG arc commands are mathematically undefined when the
+arc's start and end points are the same point, which occurs when the sweep
+angle is exactly 360°. The SVG specification states that in this case the arc
+must not be drawn at all. A chart with a single non-zero-value segment, or
+with all other segments having zero/filtered-out values, passes
+`valueSegment / valueSegmentsTotal = 1 → angleDegrees = 360` to
+`createSvgCommandsString`. The resulting arc commands produce either an
+invisible segment or, in some renderers, a single dot.
+
+**Fix:** Clamp `angleDegrees` to a maximum of `359.9999` — the arc closes to
+within 0.0001° of a full circle, visually indistinguishable, but the start and
+end points are never identical so the arc renders correctly in all SVG engines.
+
+**Test:** `createChartSegmentPathDraw.spec.ts` — new test with
+`valueSegment: 1, valueSegmentsTotal: 1, valueSegmentsPreviousTotal: 0`
+asserts the returned path is non-empty and contains no `'NaN'` tokens.
+
+---
+
+### Bug 5: `order: 0` was silently discarded and replaced with a fallback
+
+**File:** `src/hooks/useChartDataRemap.ts`
+
+**Before:**
+```ts
+order = item.order || dataValid.length + 1 + i;
+```
+
+**After:**
+```ts
+order = item.order ?? dataValid.length + 1 + i;
+```
+
+**Why it's a bug:** JavaScript's `||` (logical OR) evaluates the right-hand
+side whenever the left-hand side is **falsy**. `0` is falsy. So any data item
+with `order: 0` had its explicit order silently replaced with
+`dataValid.length + 1 + i` — a large positive number — causing it to sort last
+instead of first. Consumers who intentionally provided `order: 0` (the lowest
+priority value) got wrong sort order without any error or warning.
+
+**Fix:** Nullish coalescing `??` only falls back when the value is `null` or
+`undefined`, leaving `0` (and any other defined numeric value) intact.
+
+**Test:** `useChartDataRemap.spec.tsx` — new test provides two items with
+`order: 0` and `order: 1` respectively; asserts that the item with `order: 0`
+is first in the result.
+
+---
+
+### Additional: negative and `Infinity` data values not filtered
+
+**File:** `src/hooks/useChartDataRemap.ts`
+
+**Before:**
+```ts
+const dataValid = dataProp.filter((segment) => !!segment.value);
+```
+
+**After:** Extended to also warn and exclude segments where `value < 0` or
+`!isFinite(value)`.
+
+**Why it's needed:** The existing `!!segment.value` filter correctly excluded
+`value: 0` (intentional — zero-area arcs cannot be drawn). However, `!!-1` is
+`true` and `!!Infinity` is `true`, so negative and infinite segment values
+passed through silently. A negative value in `valueSegmentsTotal` would
+ultimately cause incorrect angle calculations for all other segments. An
+`Infinity` value was partly addressed by Bug 3 above (the geometry guard), but
+it's better to reject invalid data at the input boundary with a clear warning,
+before the data enters the render pipeline at all.
+
+**Tests:** `useChartDataRemap.spec.tsx` — three new tests:
+- Item with `value: -10` → filtered out (1 item removed), `consoleWarn` called
+- Item with `value: Infinity` → filtered out (1 item removed), `consoleWarn` called
+- All items invalid (`value: -5` and `value: 0`) → result is empty array
+
+---
+
+## New test count
+
+| File | Tests added |
+|---|---|
+| `src/utils/__TESTS__/color.spec.ts` | +1 |
+| `src/utils/__TESTS__/sanitizeNumber.spec.ts` | +2 |
+| `src/utils/__TESTS__/createChartSegmentPathDraw/utils/checkIncomingValues.spec.ts` | +2 |
+| `src/utils/__TESTS__/createChartSegmentPathDraw/utils/createChartSegmentPathDraw.spec.ts` | +1 |
+| `src/hooks/__TESTS__/useChartDataRemap.spec.tsx` | +4 |
+| **Total** | **+10** |
+
+Test suites: 57/57 (unchanged).
+Tests: 160 → **170** (+10).
+
+---
+
+## Local checks
+
+- `pnpm run check` ✅ 0 errors
+- `pnpm run lint` ✅ 0 errors
+- `pnpm run format:check` ✅ 0 errors
+- `pnpm run type-check` ✅ 0 errors
+- `pnpm run type-check:test` ✅ 0 errors
+- `pnpm run build` ✅ 0 errors
+- `pnpm run test` ✅ 57/57 suites, 170/170 tests
+- `pnpm run test:cover` ✅ 57/57 suites, 170/170 tests
+- `pnpm run pack:smoke` ✅ CJS/ESM/TypeScript consumers verified
+- `pnpm run size` ✅ within limits
+- `pnpm run check:all` ✅ exit 0
+- `pnpm audit` ✅ 0 vulnerabilities
+
+---
+
+## What was NOT done
+
+- No changes to public API, exported types, or component props.
+- No visual or structural changes to SVG output (only coordinates corrected).
+- No `dist/` committed.
+- CI remains disabled (Stage 01).
+- Publish remains no-op (Stage 01).
+- The `convertPercentToDegrees.spec.ts` coverage was reviewed and left as-is —
+  no additional gaps found in that utility's test coverage.
+- `getPointCoords` was reviewed and found correct — no changes needed.

--- a/src/hooks/__TESTS__/useChartDataRemap.spec.tsx
+++ b/src/hooks/__TESTS__/useChartDataRemap.spec.tsx
@@ -110,4 +110,83 @@ describe('hook "useChartDataRemap"', () => {
 
     expect(result.current).toHaveLength(USE_CHART_DATA_REMAP_TEST_PROPS_DATA_COMPLETE_SORTED.length * 2);
   });
+
+  it('preserves "order: 0" — zero order must not be treated as falsy/missing', () => {
+    expect.assertions(2);
+
+    const { result } = renderHook(() =>
+      useChartDataRemap({
+        data: [
+          { color: '#ff0000', id: 'a', order: 0, value: 10 },
+          { color: '#0000ff', id: 'b', order: 1, value: 20 }
+        ],
+        gap: 0
+      })
+    );
+
+    /**
+     * Item with order:0 must sort before item with order:1.
+     * If "order: 0" were treated as falsy and replaced by a fallback,
+     * the fallback would be > 1, so item 'a' would appear LAST instead of FIRST.
+     */
+    expect(result.current[0].id).toBe('a');
+    expect(result.current[1].id).toBe('b');
+  });
+
+  it('filters out data items with negative "value" and warns via consoleWarn', () => {
+    expect.assertions(2);
+
+    const { consoleWarnMocked } = mockConsole();
+
+    const { result } = renderHook(() =>
+      useChartDataRemap({
+        data: [
+          { color: '#ff0000', id: 'a', order: 1, value: -10 },
+          { color: '#0000ff', id: 'b', order: 2, value: 20 }
+        ],
+        gap: 0
+      })
+    );
+
+    // Only the valid item should survive
+    expect(result.current).toHaveLength(1);
+    expect(consoleWarnMocked).toHaveBeenCalled();
+  });
+
+  it('filters out data items with Infinity "value" and warns via consoleWarn', () => {
+    expect.assertions(2);
+
+    const { consoleWarnMocked } = mockConsole();
+
+    const { result } = renderHook(() =>
+      useChartDataRemap({
+        data: [
+          { color: '#ff0000', id: 'a', order: 1, value: Infinity },
+          { color: '#0000ff', id: 'b', order: 2, value: 20 }
+        ],
+        gap: 0
+      })
+    );
+
+    expect(result.current).toHaveLength(1);
+    expect(consoleWarnMocked).toHaveBeenCalled();
+  });
+
+  it('returns an empty array when all data items have invalid values', () => {
+    expect.assertions(1);
+
+    mockConsole();
+
+    const { result } = renderHook(() =>
+      useChartDataRemap({
+        data: [
+          { color: '#ff0000', id: 'a', order: 1, value: -5 },
+          { color: '#0000ff', id: 'b', order: 2, value: 0 }
+        ],
+        gap: 0
+      })
+    );
+
+    expect(result.current).toHaveLength(0);
+  });
 });

--- a/src/hooks/useChartDataRemap.ts
+++ b/src/hooks/useChartDataRemap.ts
@@ -28,7 +28,33 @@ export const useChartDataRemap = (props: TUseChartDataRemap): TDataItemRequired[
   const { data: dataProp, gap } = props;
 
   const incomingData = useMemo(() => {
-    const dataValid = dataProp.filter((segment) => !!segment.value);
+    /**
+     * Filter to only segments with a finite positive value:
+     * - value: 0   → excluded (can't draw a zero-size arc; intentional)
+     * - value < 0  → excluded (nonsensical in a pie/donut context; warns)
+     * - value: Infinity / -Infinity → excluded (would produce NaN coords; warns)
+     * - value: NaN → excluded (already falsy, but handled explicitly below)
+     *
+     * Note: `!!0 === false` so zero is already excluded by the `!!segment.value` check;
+     * negatives and Infinity both pass `!!`, so we need explicit guards for them.
+     */
+    const dataValid = dataProp.filter((segment) => {
+      if (!segment.value) {
+        return false;
+      }
+
+      if (!isFinite(segment.value) || segment.value < 0) {
+        consoleWarn(`
+          Data item param "value" error: Must be a finite positive number.
+          
+          Provided: "value" = ${segment.value}
+          This item will be excluded from the chart.
+          `);
+        return false;
+      }
+
+      return true;
+    });
 
     if (!dataValid.length) {
       return [];
@@ -66,7 +92,13 @@ export const useChartDataRemap = (props: TUseChartDataRemap): TDataItemRequired[
         order = 0;
 
         if (dataValid.length > 1) {
-          order = item.order || dataValid.length + 1 + i;
+          /**
+           * Use nullish coalescing (??) rather than logical OR (||) so that
+           * order: 0 is preserved. With ||, `0 || fallback` would always pick
+           * the fallback, treating 0 as "no order provided" — a bug that caused
+           * items with order:0 to be sorted after all explicitly-ordered items.
+           */
+          order = item.order ?? dataValid.length + 1 + i;
         }
 
         return {

--- a/src/utils/__TESTS__/color.spec.ts
+++ b/src/utils/__TESTS__/color.spec.ts
@@ -10,6 +10,30 @@ describe('function "randomColorHEX"', () => {
 
     expect(HEX_REG_EXP.test(color)).toBeTruthy();
   });
+
+  it('returns a valid HEX color even when Math.random returns a value very close to 1 (boundary case)', () => {
+    expect.assertions(2);
+
+    const originalRandom = Math.random;
+    /**
+     * When Math.random() = 0.999999:
+     *   - Correct formula: Math.floor(0.999999 * 256) = Math.floor(255.999744) = 255
+     *     → channel 255 → all-channels-255 color = '#ffffff'
+     *   - Buggy formula:   Math.floor(0.999999 * 257) = Math.floor(256.999743) = 256
+     *     → channel 256 overflows the 8-bit range; the bitwise hex computation wraps to
+     *       produce '#010100' instead of '#ffffff' — a wrong, though still 7-char, result.
+     */
+    Math.random = () => 0.999999;
+
+    try {
+      const color = randomColorHEX();
+
+      expect(HEX_REG_EXP.test(color)).toBeTruthy();
+      expect(color).toBe('#ffffff');
+    } finally {
+      Math.random = originalRandom;
+    }
+  });
 });
 
 describe('function "convertHexToRgb"', () => {

--- a/src/utils/__TESTS__/createChartSegmentPathDraw/utils/checkIncomingValues.spec.ts
+++ b/src/utils/__TESTS__/createChartSegmentPathDraw/utils/checkIncomingValues.spec.ts
@@ -25,4 +25,30 @@ describe('function "checkIncomingValues"', () => {
     expect(check).not.toBeTruthy();
     expect(consoleErrorMocked).toHaveBeenCalledTimes(1);
   });
+
+  it('returns false when "valueSegment" is Infinity (Infinity passes isNaN but causes NaN in geometry)', () => {
+    expect.assertions(2);
+    const { consoleErrorMocked } = mockConsole();
+
+    const check = checkIncomingValues({
+      ...CHECK_INCOMING_VALUES_TEST_VALUES_VALID,
+      valueSegment: Infinity
+    });
+
+    expect(check).not.toBeTruthy();
+    expect(consoleErrorMocked).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false when "valueSegmentsTotal" is Infinity', () => {
+    expect.assertions(2);
+    const { consoleErrorMocked } = mockConsole();
+
+    const check = checkIncomingValues({
+      ...CHECK_INCOMING_VALUES_TEST_VALUES_VALID,
+      valueSegmentsTotal: Infinity
+    });
+
+    expect(check).not.toBeTruthy();
+    expect(consoleErrorMocked).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/utils/__TESTS__/createChartSegmentPathDraw/utils/createChartSegmentPathDraw.spec.ts
+++ b/src/utils/__TESTS__/createChartSegmentPathDraw/utils/createChartSegmentPathDraw.spec.ts
@@ -26,4 +26,27 @@ describe('function "createChartSegmentPathDraw"', () => {
     expect(path).toBe('');
     expect(consoleErrorMocked).toHaveBeenCalledTimes(1);
   });
+
+  it('returns a non-empty path without NaN when a single segment takes 100% (full circle)', () => {
+    expect.assertions(2);
+    mockConsole();
+
+    /**
+     * A single segment equals 100% of the chart:
+     *   valueSegment / valueSegmentsTotal = 1 → angleDegrees = 360.
+     * A naive SVG arc command for exactly 360° has the same start and end point,
+     * which SVG spec defines as a degenerate arc (renders as nothing).
+     * The function must clamp or split the arc so the path is both non-empty
+     * and contains no "NaN" tokens.
+     */
+    const path = createChartSegmentPathDraw({
+      ...CHECK_INCOMING_VALUES_TEST_VALUES_VALID,
+      valueSegment: 1,
+      valueSegmentsTotal: 1,
+      valueSegmentsPreviousTotal: 0
+    });
+
+    expect(path).not.toBe('');
+    expect(path).not.toContain('NaN');
+  });
 });

--- a/src/utils/__TESTS__/sanitizeNumber.spec.ts
+++ b/src/utils/__TESTS__/sanitizeNumber.spec.ts
@@ -32,4 +32,25 @@ describe('function "sanitizeNumber"', () => {
 
     expect(sanitizedValue).toBe(DEFAULT_SANITISE_NUMBER_VALUE);
   });
+
+  it('returns the default fallback for Infinity (not a valid finite number for geometry)', () => {
+    expect.assertions(2);
+
+    const { consoleErrorMocked } = mockConsole();
+    const testDefault = 5;
+    const sanitizedValue = sanitizeNumber(Infinity, testDefault);
+
+    expect(sanitizedValue).toBe(testDefault);
+    expect(consoleErrorMocked).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the default fallback for -Infinity', () => {
+    expect.assertions(2);
+
+    const { consoleErrorMocked } = mockConsole();
+    const sanitizedValue = sanitizeNumber(-Infinity);
+
+    expect(sanitizedValue).toBe(DEFAULT_SANITISE_NUMBER_VALUE);
+    expect(consoleErrorMocked).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,6 +1,12 @@
 import { consoleError, createErrorWithDescription } from 'utils/console';
 
-const ChanelRand = (): number => Math.floor(Math.random() * (256 + 1));
+/**
+ * Returns a random integer in [0, 255].
+ * The correct multiplier is 256 (not 257): Math.random() returns [0, 1), so
+ * Math.floor(x * 256) ≤ 255 always. Using (256 + 1) could produce the value 256,
+ * which overflows an 8-bit channel and corrupts the resulting hex colour.
+ */
+const ChanelRand = (): number => Math.floor(Math.random() * 256);
 
 type TRGBRandReturn = [number, number, number];
 

--- a/src/utils/createChartSegmentPathDraw/_utils/checkIncomingValues.ts
+++ b/src/utils/createChartSegmentPathDraw/_utils/checkIncomingValues.ts
@@ -11,9 +11,12 @@ export const checkIncomingValues = (props: TCreateChartSegmentPathDraw) => {
 
   const isNotValid =
     isNaN(valueSegment) ||
+    !isFinite(valueSegment) ||
     isNaN(valueSegmentsPreviousTotal) ||
+    !isFinite(valueSegmentsPreviousTotal) ||
     isNaN(size) ||
     isNaN(valueSegmentsTotal) ||
+    !isFinite(valueSegmentsTotal) ||
     isNaN(radiusOuter) ||
     isNaN(radiusInner) ||
     valueSegment > valueSegmentsTotal ||

--- a/src/utils/createChartSegmentPathDraw/_utils/createSvgCommandsString.ts
+++ b/src/utils/createChartSegmentPathDraw/_utils/createSvgCommandsString.ts
@@ -22,7 +22,16 @@ type TCreateSvgCommandsString = {
  * @return { string } path
  */
 export const createSvgCommandsString = (props: TCreateSvgCommandsString) => {
-  const { angleDegrees, radiusInner, radiusOuter, size } = props;
+  const { radiusInner, radiusOuter, size } = props;
+
+  /**
+   * SVG arc commands are undefined when the start and end points are identical,
+   * which happens when angleDegrees is exactly 360 (a full circle). Clamp to
+   * just under 360 so the arc end point is never the same as the start point.
+   * The visual difference is imperceptible (< 0.001° missing) but prevents the
+   * degenerate arc that would otherwise render as nothing.
+   */
+  const angleDegrees = Math.min(props.angleDegrees, 359.9999);
 
   /**
    * Here we determine which way the arc will be formed to the point - along a short or long one.

--- a/src/utils/sanitizeNumber.ts
+++ b/src/utils/sanitizeNumber.ts
@@ -10,7 +10,7 @@ export const DEFAULT_SANITISE_NUMBER_VALUE = 0;
  * @return { number } - sanitized number
  */
 export const sanitizeNumber = (n: number, defaultNumber = DEFAULT_SANITISE_NUMBER_VALUE) => {
-  if (isNaN(n)) {
+  if (isNaN(n) || !isFinite(n)) {
     consoleError(
       createErrorWithDescription({
         messageMain: 'In most cases, this error is caused by invalid props.',


### PR DESCRIPTION
## Summary

Fixed 5 confirmed bugs in data validation and geometry calculation code.

All fixes are covered by new tests written **before** the fix was applied (red → green, in that order). All **57 test suites, 170 tests** pass (+10 tests vs. the previous PR). `pnpm run check:all` passes end-to-end. Full details in `docs/maintenance/08-data-geometry-fixes.md`.

## Bug 1: `ChanelRand` could return 256 → corrupted random hex colour

**File:** `src/utils/color.ts`

`Math.floor(Math.random() * 257)` can evaluate to 256 when `Math.random()` ≈ 0.999999 (`Math.floor(256.999…) = 256`). An RGB channel of 256 overflows the valid 8-bit range. The subsequent bitwise `rgbToHex` operation produces a wrong colour (e.g. `#010100` instead of `#ffffff`). The string still passes the hex regex, making this silent and hard to detect.

**Fix:** `Math.floor(Math.random() * 256)` — since `Math.random()` is `[0, 1)`, the result is always ≤ 255.

**Test:** mocks `Math.random = () => 0.999999`, asserts `randomColorHEX() === '#ffffff'`. Fails with old formula.

## Bug 2: `sanitizeNumber` silently passed `Infinity` / `-Infinity`

**File:** `src/utils/sanitizeNumber.ts`

`isNaN(Infinity) === false`. Any `Infinity` prop value (e.g. `donutThickness`, `gap`, `fontSize`) would pass the existing guard and propagate to SVG geometry, where `Infinity * cos(…) = NaN` — invisible or broken chart segments with no error.

**Fix:** Added `!isFinite(n)` to the rejection guard.

**Tests:** `sanitizeNumber(Infinity, default)` → returns `default` + `consoleError` called; same for `-Infinity`.

## Bug 3: `checkIncomingValues` did not reject `Infinity` in segment values

**File:** `src/utils/createChartSegmentPathDraw/_utils/checkIncomingValues.ts`

Same root cause: `isNaN(Infinity) === false`. An `Infinity` `valueSegment` or `valueSegmentsTotal` passed the existing guard and reached `createSvgCommandsString`, where `360 * (Infinity / total) = Infinity` and `Math.cos(Infinity * π / 180) = NaN`, producing `NaN NaN` in the SVG `d` attribute.

**Fix:** Added `!isFinite(valueSegment)`, `!isFinite(valueSegmentsPreviousTotal)`, `!isFinite(valueSegmentsTotal)` guards.

**Tests:** `valueSegment: Infinity` → returns `false` + `consoleError`; same for `valueSegmentsTotal: Infinity`.

## Bug 4: Single-segment chart (100% = 360°) rendered invisible

**File:** `src/utils/createChartSegmentPathDraw/_utils/createSvgCommandsString.ts`

When a chart has one data item (or all others are filtered out), `valueSegment / valueSegmentsTotal = 1` → `angleDegrees = 360`. SVG arc commands are undefined when start and end points are identical (a full 360° sweep). Per SVG spec, the arc must not be drawn — the segment renders as nothing.

**Fix:** `const angleDegrees = Math.min(props.angleDegrees, 359.9999)`. Visually imperceptible (<0.001° gap), but start ≠ end so the arc renders correctly in all SVG engines.

**Test:** `valueSegment: 1, valueSegmentsTotal: 1, valueSegmentsPreviousTotal: 0` → path is non-empty and contains no `'NaN'` tokens.

## Bug 5: `order: 0` silently treated as "no order provided"

**File:** `src/hooks/useChartDataRemap.ts`

```ts
// Before (buggy):
order = item.order || dataValid.length + 1 + i;

// After (fixed):
order = item.order ?? dataValid.length + 1 + i;
```

`0` is falsy in JavaScript. `||` evaluates the right-hand side for any falsy left-hand side, so `order: 0` was always silently replaced by `dataValid.length + 1 + i` — a large positive number — causing items with `order: 0` to sort last instead of first. No error, no warning.

**Fix:** Nullish coalescing `??` falls back only when the value is `null` or `undefined`, preserving `0`.

**Test:** Two items with `order: 0` and `order: 1` — asserts the `order: 0` item is first in the result.

### Bonus fix in same file: negative and Infinity values not filtered

`!!-1 === true` and `!!Infinity === true`, so both passed the existing `!!segment.value` filter silently. Extended the filter to also warn and exclude items with `value < 0` or `!isFinite(value)`.

**Tests:** item with `value: -10` → filtered out + `consoleWarn`; item with `value: Infinity` → filtered out + `consoleWarn`; all items invalid → empty result.

## New tests

| File | Tests added |
|---|---|
| `src/utils/__TESTS__/color.spec.ts` | +1 |
| `src/utils/__TESTS__/sanitizeNumber.spec.ts` | +2 |
| `src/utils/__TESTS__/createChartSegmentPathDraw/utils/checkIncomingValues.spec.ts` | +2 |
| `src/utils/__TESTS__/createChartSegmentPathDraw/utils/createChartSegmentPathDraw.spec.ts` | +1 |
| `src/hooks/__TESTS__/useChartDataRemap.spec.tsx` | +4 |
| **Total** | **+10** |

**57 suites / 160 tests → 57 suites / 170 tests**

## Local checks

- [x] `pnpm run check` — 0 errors
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run format:check` — 0 errors
- [x] `pnpm run type-check` — 0 errors
- [x] `pnpm run type-check:test` — 0 errors
- [x] `pnpm run build` — 0 errors
- [x] `pnpm run test` — 57/57 suites, 170/170 tests
- [x] `pnpm run test:cover` — 57/57 suites, 170/170 tests
- [x] `pnpm run pack:smoke` — CJS/ESM/TypeScript consumers verified
- [x] `pnpm run size` — within limits
- [x] `pnpm run check:all` — exit 0
- [x] `pnpm audit` — 0 vulnerabilities

## Scope

No public API changes. No changes to SVG output structure (only coordinate values corrected). No new runtime dependencies. No `dist/` committed. CI and publish remain disabled.
