### PR TITLE
feat: improve chart accessibility semantics

### DIFF
--- a/docs/maintenance/10-accessibility-improvements.md
+++ b/docs/maintenance/10-accessibility-improvements.md
@@ -1,0 +1,70 @@
+# Stage 10 — Accessibility improvements
+
+## Summary
+
+- Added optional chart and segment accessible labels via `ariaLabel` and `getSegmentAriaLabel` props.
+- Added `role="img"` and `aria-label` to the root `<svg>` element.
+- Added `role="button"`, `aria-label`, and `aria-pressed` to interactive segment `<path>` elements.
+- Added Space key activation alongside the existing Enter key, preventing default page-scroll behavior.
+- Preserved all existing public API, callback signatures, and `tabIndex` behavior.
+- Kept CI disabled.
+- Kept publish disabled/no-op.
+
+## New optional props
+
+- `ariaLabel?: string` — Sets the `aria-label` on the root `<svg>`. Defaults to `"Pie donut chart"` when not provided.
+- `getSegmentAriaLabel?: (segment: DataItem, index: number) => string` — Factory for per-segment accessible names. Defaults to `"Segment <id>: value <value>"` when not provided.
+
+## SVG accessibility
+
+- **Previous behavior:** `<svg>` had no `role` and no `aria-label`; assistive technology had no semantic information about the chart.
+- **New behavior:** `<svg role="img" aria-label="Pie donut chart">` (or the caller-supplied label). The constant `DEFAULT_CHART_ARIA_LABEL = 'Pie donut chart'` is exported from `PieDonutChart.tsx` for use in tests and consumers.
+- **Tests:** `src/__TESTS__/accessibility/PieDonutChart.accessibility.spec.tsx` — default label, custom label, SSR (via existing `src/__TESTS__/ssr/render.spec.tsx`).
+
+## Segment accessibility
+
+- **Interactive segment role:** `role="button"` on non-gap `<path>` elements.
+- **Accessible label:** `aria-label` populated by `getSegmentAriaLabel(segment, index)` or the built-in default `"Segment <id>: value <value>"`. Gap segments receive no `aria-label` and no `role`.
+- **Selected state:** `aria-pressed={isSelected}` on non-gap segments (matches WAI-ARIA pattern for toggle buttons).
+- **Non-interactive behavior:** Gap segments (`isGapSegment === true`) receive `role={undefined}`, `aria-label={undefined}`, and `aria-pressed={undefined}`, preserving the existing `tabIndex={-1}` behavior.
+- **Tests:** segment role, default/custom labels, `aria-pressed` state, non-interactive paths not exposed as buttons.
+
+## Keyboard behavior
+
+- **Enter:** Unchanged — triggers selection and calls `onSegmentKeyEnterDown` (via `isKeyDownEnter`).
+- **Space:** New — also triggers selection and calls `onSegmentKeyEnterDown`; `e.preventDefault()` is called to suppress default page-scroll. Implementation uses the new `isKeyDownSpace` utility (`src/utils/isKeyDownSpace.ts`).
+- **Existing callback compatibility:** `onSegmentKeyEnterDown` is called for both Enter and Space (consistent with WAI-ARIA button activation pattern where both keys are equivalent activators).
+
+## New files
+
+- `src/utils/isKeyDownSpace.ts` — utility mirroring `isKeyDownEnter`, detects `e.code === 'Space'`, `e.key === ' '`, or `e.key === 'space'`.
+- `src/utils/__TESTS__/isKeyDownSpace.spec.ts` — 6 unit tests.
+- `src/__TESTS__/accessibility/PieDonutChart.accessibility.spec.tsx` — 10 integration tests covering SVG role/label, segment role/label/state, and keyboard activation.
+
+## Compatibility
+
+- Breaking changes: **no**
+- New runtime dependencies: **no**
+- TypeScript consumer verified by `pack:smoke`: **yes**
+
+## Local checks
+
+- `pnpm install`: ✅
+- `pnpm run check`: ✅ (0 errors, 37 pre-existing warnings in `scripts/`)
+- `pnpm run lint`: ✅
+- `pnpm run format:check`: ✅
+- `pnpm run type-check`: ✅
+- `pnpm run type-check:test`: ✅
+- `pnpm run build`: ✅
+- `pnpm run test`: ✅ 60 suites / 197 tests
+- `pnpm run test:cover`: ✅
+- `pnpm run pack:smoke`: ✅ All package smoke tests passed
+- `pnpm run size`: ✅ 10.08–10.19 kB (limit 15 kB)
+- `pnpm run check:all`: ✅
+- `pnpm audit`: ✅ No known vulnerabilities
+
+## Known issues left for later PRs
+
+- README/demo refresh remains for a later PR.
+- CI remains disabled.
+- Publish workflow remains no-op.

--- a/src/__TESTS__/accessibility/PieDonutChart.accessibility.spec.tsx
+++ b/src/__TESTS__/accessibility/PieDonutChart.accessibility.spec.tsx
@@ -1,0 +1,147 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DEFAULT_CHART_ARIA_LABEL, PieDonutChart, TEST_DATA_ID_CHART_SVG_MAIN } from 'components/PieDonutChart';
+import React from 'react';
+import { TEST_CHART_PROPS_COMMON } from 'tests/mocks/variables';
+
+/**
+ * Accessibility tests for the PieDonutChart component.
+ * Covers WAI-ARIA roles, labels, keyboard interaction, and structure.
+ */
+describe('PieDonutChart — accessibility', () => {
+  describe('SVG element', () => {
+    it('has role="img" on the root <svg>', () => {
+      expect.assertions(1);
+
+      const { getByTestId } = render(<PieDonutChart {...TEST_CHART_PROPS_COMMON} />);
+
+      expect(getByTestId(TEST_DATA_ID_CHART_SVG_MAIN)).toHaveAttribute('role', 'img');
+    });
+
+    it('has a default aria-label when no ariaLabel prop is provided', () => {
+      expect.assertions(1);
+
+      const { getByTestId } = render(<PieDonutChart {...TEST_CHART_PROPS_COMMON} />);
+
+      expect(getByTestId(TEST_DATA_ID_CHART_SVG_MAIN)).toHaveAttribute('aria-label', DEFAULT_CHART_ARIA_LABEL);
+    });
+
+    it('uses the provided ariaLabel prop as aria-label', () => {
+      expect.assertions(1);
+
+      const customLabel = 'Sales breakdown chart';
+      const { getByTestId } = render(<PieDonutChart {...TEST_CHART_PROPS_COMMON} ariaLabel={customLabel} />);
+
+      expect(getByTestId(TEST_DATA_ID_CHART_SVG_MAIN)).toHaveAttribute('aria-label', customLabel);
+    });
+  });
+
+  describe('segment elements', () => {
+    it('interactive segments have role="button"', () => {
+      expect.assertions(1);
+
+      const { getAllByRole } = render(<PieDonutChart {...TEST_CHART_PROPS_COMMON} gap={0} />);
+
+      const buttons = getAllByRole('button');
+
+      expect(buttons.length).toBeGreaterThan(0);
+    });
+
+    it('interactive segments have a default aria-label when no getSegmentAriaLabel is provided', () => {
+      const { getAllByRole } = render(<PieDonutChart {...TEST_CHART_PROPS_COMMON} gap={0} />);
+
+      const buttons = getAllByRole('button');
+
+      /**
+       * Every interactive segment must have a non-empty aria-label so that
+       * screen-readers can announce the segment without any configuration.
+       */
+      expect(buttons.length).toBeGreaterThan(0);
+      buttons.forEach((button) => {
+        expect(button.getAttribute('aria-label')).toBeTruthy();
+      });
+    });
+
+    it('uses getSegmentAriaLabel factory for segment aria-labels', () => {
+      const { getAllByRole } = render(
+        <PieDonutChart
+          {...TEST_CHART_PROPS_COMMON}
+          gap={0}
+          getSegmentAriaLabel={(segment) => `Segment value: ${segment.value}`}
+        />
+      );
+
+      const buttons = getAllByRole('button');
+
+      expect(buttons.length).toBeGreaterThan(0);
+      buttons.forEach((button) => {
+        expect(button.getAttribute('aria-label')).toMatch(/^Segment value: /);
+      });
+    });
+
+    it('interactive segments have aria-pressed reflecting selection state', () => {
+      expect.assertions(1);
+
+      const firstId = TEST_CHART_PROPS_COMMON.data[0].id as string;
+
+      const { getAllByRole } = render(<PieDonutChart {...TEST_CHART_PROPS_COMMON} gap={0} selected={firstId} />);
+
+      const buttons = getAllByRole('button');
+      const pressedButtons = buttons.filter((b) => b.getAttribute('aria-pressed') === 'true');
+
+      expect(pressedButtons.length).toBe(1);
+    });
+  });
+
+  describe('keyboard interaction', () => {
+    it('Space key activates a segment (calls onSegmentKeyEnterDown)', () => {
+      expect.assertions(1);
+
+      const onSegmentKeyEnterDown = jest.fn();
+
+      const { getAllByRole } = render(
+        <PieDonutChart {...TEST_CHART_PROPS_COMMON} gap={0} onSegmentKeyEnterDown={onSegmentKeyEnterDown} />
+      );
+
+      const [firstButton] = getAllByRole('button');
+
+      firstButton.focus();
+      userEvent.keyboard(' ');
+
+      expect(onSegmentKeyEnterDown).toHaveBeenCalledTimes(1);
+    });
+
+    it('Enter key activates a segment (calls onSegmentKeyEnterDown)', () => {
+      expect.assertions(1);
+
+      const onSegmentKeyEnterDown = jest.fn();
+
+      const { getAllByRole } = render(
+        <PieDonutChart {...TEST_CHART_PROPS_COMMON} gap={0} onSegmentKeyEnterDown={onSegmentKeyEnterDown} />
+      );
+
+      const [firstButton] = getAllByRole('button');
+
+      firstButton.focus();
+      userEvent.keyboard('{Enter}');
+
+      expect(onSegmentKeyEnterDown).toHaveBeenCalledTimes(1);
+    });
+
+    it('Tab key moves focus between segments', () => {
+      expect.assertions(2);
+
+      const data = TEST_CHART_PROPS_COMMON.data.slice(0, 2);
+
+      const { getAllByRole } = render(<PieDonutChart {...TEST_CHART_PROPS_COMMON} data={data} gap={0} tabIndex={0} />);
+
+      const [first, second] = getAllByRole('button');
+
+      first.focus();
+      expect(document.activeElement).toBe(first);
+
+      userEvent.tab();
+      expect(document.activeElement).toBe(second);
+    });
+  });
+});

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -4,6 +4,7 @@ import { computePrefixTotals } from 'utils/computePrefixTotals';
 import { convertPercentToDegrees } from 'utils/createChartSegmentPathDraw/_utils/convertPercentToDegrees';
 import { createChartSegmentPathDraw } from 'utils/createChartSegmentPathDraw/createChartSegmentPathDraw';
 import { isKeyDownEnter } from 'utils/isKeyDownEnter';
+import { isKeyDownSpace } from 'utils/isKeyDownSpace';
 import { sanitizeNumber } from 'utils/sanitizeNumber';
 import { DEFAULT_COLOR_SEGMENT_FOCUSED_OUTLINE, SINGLE_VALUE_CORRECTION_RATIO } from 'variables/defaults';
 
@@ -27,6 +28,7 @@ export type TChartProps = Pick<
   | 'donutThickness'
   | 'focusedSegment'
   | 'gap'
+  | 'getSegmentAriaLabel'
   | 'handleClearSelects'
   | 'hoverScaleRatio'
   | 'hoveredSegment'
@@ -66,6 +68,7 @@ export const Chart = (props: TChartProps) => {
     donutThickness,
     focusedSegment,
     gap,
+    getSegmentAriaLabel,
     handleClearSelects,
     hoverScaleRatio,
     hoveredSegment,
@@ -216,6 +219,18 @@ export const Chart = (props: TChartProps) => {
         });
 
         /**
+         * Accessible label for this segment.
+         * Uses the caller-supplied factory if provided; falls back to a
+         * descriptive default so screen-reader users always hear something
+         * meaningful, even without any configuration.
+         */
+        const segmentAriaLabel = isGapSegment
+          ? undefined
+          : getSegmentAriaLabel
+            ? getSegmentAriaLabel(item, i)
+            : `Segment ${id ?? i}: value ${value}`;
+
+        /**
          * Tests attributes (gap segments)
          */
         const testsAttributesGap = { [TEST_DATA_ATTR_CHART_GROUP_SEGMENT_GAP]: gap };
@@ -233,11 +248,14 @@ export const Chart = (props: TChartProps) => {
         return (
           <path
             {...testsAttributes}
+            aria-label={segmentAriaLabel}
+            aria-pressed={isGapSegment ? undefined : isSelected}
             className={classNameSegment}
             d={segmentPath}
             data-testid={TEST_DATA_ID_CHART_GROUP_SEGMENT}
             fill={color}
             key={`chart-segment-${id}`}
+            role={isGapSegment ? undefined : 'button'}
             onClick={() => {
               if (isGapSegment) {
                 return;
@@ -260,6 +278,21 @@ export const Chart = (props: TChartProps) => {
             }}
             onKeyDownCapture={(e) => {
               if (isGapSegment) {
+                return;
+              }
+
+              /**
+               * Space activates a button-role element (WAI-ARIA pattern).
+               * preventDefault prevents the default page-scroll behaviour.
+               */
+              if (isKeyDownSpace(e)) {
+                e.preventDefault();
+
+                if (isSelectOnKeyEnterDown && selected !== id) {
+                  setSelected(id);
+                }
+
+                onSegmentKeyEnterDown?.(id);
                 return;
               }
 

--- a/src/components/PieDonutChart.tsx
+++ b/src/components/PieDonutChart.tsx
@@ -13,6 +13,8 @@ import {
 
 export const TEST_DATA_ID_CHART_SVG_MAIN = 'TEST_DATA_ID_CHART_SVG_MAIN';
 
+export const DEFAULT_CHART_ARIA_LABEL = 'Pie donut chart';
+
 export const PieDonutChart: typeof PieDonutChartType = (props: PieDonutChartProps): JSX.Element => {
   const { classNames: classNamesProp, colors: colorsProp, ...rest } = props;
 
@@ -47,8 +49,10 @@ export const PieDonutChart: typeof PieDonutChartType = (props: PieDonutChartProp
 
   return (
     <svg
+      aria-label={properties.ariaLabel || DEFAULT_CHART_ARIA_LABEL}
       className={properties.className}
       data-testid={TEST_DATA_ID_CHART_SVG_MAIN}
+      role="img"
       style={{
         alignItems: 'center',
         aspectRatio: '1 / 1',

--- a/src/components/__TESTS__/Chart.spec.tsx
+++ b/src/components/__TESTS__/Chart.spec.tsx
@@ -46,6 +46,7 @@ const CHART_TEST_PROPS: TChartProps = {
   donutThickness: TEST_PROPS.donutThickness,
   focusedSegment: null,
   gap: TEST_PROPS.gap,
+  getSegmentAriaLabel: undefined,
   handleClearSelects: stubDefault,
   hoverScaleRatio: TEST_PROPS.hoverScaleRatio,
   hoveredSegment: null,

--- a/src/hooks/useChartProps.ts
+++ b/src/hooks/useChartProps.ts
@@ -36,6 +36,7 @@ export const useChartProps = (props: TUseChartProps) => {
 
   const {
     animationSpeed = DEFAULT_ANIMATION_SPEED,
+    ariaLabel,
     chartCenterSize,
     children,
     className,
@@ -58,6 +59,7 @@ export const useChartProps = (props: TUseChartProps) => {
     donutThickness: donutThicknessProp = 0,
     fontSize: fontSizeProp,
     gap = 0,
+    getSegmentAriaLabel,
     hoverScaleRatio = DEFAULT_CHART_SEGMENT_SCALE_RATIO,
     isScaleOnHover = true,
     isSelectOnClick = true,
@@ -158,6 +160,7 @@ export const useChartProps = (props: TUseChartProps) => {
   }, [properties]);
 
   return {
+    ariaLabel,
     centerSize,
     chartRef,
     children,
@@ -182,6 +185,7 @@ export const useChartProps = (props: TUseChartProps) => {
     focusedSegment,
     fontSize,
     gap,
+    getSegmentAriaLabel,
     handleClearSelects,
     hoverScaleRatio,
     hoveredSegment,

--- a/src/tests/mocks/variables.ts
+++ b/src/tests/mocks/variables.ts
@@ -83,6 +83,7 @@ export const TEST_PROPS: AllRequired<
   stylesHoveredSegment: TPieDonutChartPropsUserAll['stylesHoveredSegment'];
 } = {
   animationSpeed: 123,
+  ariaLabel: 'Test chart',
   chartCenterSize: 100,
   children: null,
   className: 'test-classname-className',
@@ -92,6 +93,7 @@ export const TEST_PROPS: AllRequired<
   donutThickness: 10,
   fontSize: 24,
   gap: 8,
+  getSegmentAriaLabel: (segment: DataItem) => `Test segment ${segment.id}`,
   hoverScaleRatio: 1.75,
   isScaleOnHover: false,
   isSelectOnClick: false,

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -291,9 +291,22 @@ export type PieDonutChartPropsColors = {
  * @property { string } text
  * @default undefined
  *
+ * Accessible label for the chart SVG element (maps to `aria-label` on the `<svg>`).
+ * If not provided, defaults to `"Pie donut chart"`.
+ * Useful when multiple charts are on the same page.
+ * @property { string } ariaLabel
+ * @default 'Pie donut chart'
+ *
+ * Returns a custom accessible label for each interactive segment.
+ * Receives the segment's DataItem and its zero-based index in the rendered order.
+ * If not provided, a default label is generated from the segment's value and id.
+ * @property { (segment: DataItem, index: number) => string } getSegmentAriaLabel
+ * @default undefined
+ *
  */
 export type PieDonutChartProps = {
   animationSpeed?: number;
+  ariaLabel?: string;
   chartCenterSize?: number;
   children?: ReactNode | string | number;
   className?: string;
@@ -303,6 +316,7 @@ export type PieDonutChartProps = {
   donutThickness?: number;
   fontSize?: number;
   gap?: number;
+  getSegmentAriaLabel?: (segment: DataItem, index: number) => string;
   hoverScaleRatio?: number;
   isScaleOnHover?: boolean;
   isSelectOnClick?: boolean;

--- a/src/utils/__TESTS__/isKeyDownSpace.spec.ts
+++ b/src/utils/__TESTS__/isKeyDownSpace.spec.ts
@@ -1,0 +1,49 @@
+import { isKeyDownSpace } from 'utils/isKeyDownSpace';
+
+describe('function "isKeyDownSpace"', () => {
+  it('returns [true] when e.code is "space" (case-insensitive)', () => {
+    expect.assertions(2);
+
+    // @ts-ignore
+    expect(isKeyDownSpace({ code: 'Space' })).toBeTruthy();
+    // @ts-ignore
+    expect(isKeyDownSpace({ code: 'space' })).toBeTruthy();
+  });
+
+  it('returns [true] when e.key is " " (the Space character)', () => {
+    expect.assertions(1);
+
+    // @ts-ignore
+    expect(isKeyDownSpace({ key: ' ' })).toBeTruthy();
+  });
+
+  it('returns [true] when e.key is "space" (case-insensitive, some older browsers)', () => {
+    expect.assertions(2);
+
+    // @ts-ignore
+    expect(isKeyDownSpace({ key: 'space' })).toBeTruthy();
+    // @ts-ignore
+    expect(isKeyDownSpace({ key: 'Space' })).toBeTruthy();
+  });
+
+  it('returns [false] for Enter key', () => {
+    expect.assertions(1);
+
+    // @ts-ignore
+    expect(isKeyDownSpace({ code: 'Enter', key: 'Enter' })).toBeFalsy();
+  });
+
+  it('returns [false] for unrelated key', () => {
+    expect.assertions(1);
+
+    // @ts-ignore
+    expect(isKeyDownSpace({ code: 'KeyA', key: 'a' })).toBeFalsy();
+  });
+
+  it('returns [false] when event has no code or key', () => {
+    expect.assertions(1);
+
+    // @ts-ignore
+    expect(isKeyDownSpace({})).toBeFalsy();
+  });
+});

--- a/src/utils/isKeyDownSpace.ts
+++ b/src/utils/isKeyDownSpace.ts
@@ -1,0 +1,16 @@
+import React from 'react';
+
+/**
+ * Defines whether the current event was fired by a Space key press.
+ *
+ * Space activates interactive elements in the same way as Enter (WAI-ARIA
+ * keyboard interaction patterns for button-role elements). It must be
+ * accompanied by `e.preventDefault()` at the call site to prevent the default
+ * browser scroll behaviour.
+ *
+ * @function isKeyDownSpace
+ * @param { React.KeyboardEvent } e - KeyboardEvent
+ * @return { boolean } - true if the Space key was pressed
+ */
+export const isKeyDownSpace = (e: React.KeyboardEvent) =>
+  e.code?.toLowerCase?.() === 'space' || e.key === ' ' || e.key?.toLowerCase?.() === 'space';


### PR DESCRIPTION
## Summary

- Added optional chart and segment accessibility labels.
- Improved SVG/segment semantics.
- Added Space key activation while preserving Enter behavior.
- Preserved backward compatibility.
- Kept CI and publish disabled during maintenance.

## New optional props

- \riaLabel?: string\ — Sets \ria-label\ on the root \<svg>\. Defaults to \'Pie donut chart'\.
- \getSegmentAriaLabel?: (segment: DataItem, index: number) => string\ — Factory for per-segment accessible names. Defaults to \'Segment <id>: value <value>'\.

## Accessibility behavior

- SVG role/name: \<svg role='img' aria-label='Pie donut chart'>\ (or caller-supplied label).
- Segment labels: \ria-label\ on each interactive \<path>\ from factory or built-in default.
- Selected state: \ria-pressed={isSelected}\ on non-gap segments.
- Keyboard Enter: unchanged — triggers selection and \onSegmentKeyEnterDown\.
- Keyboard Space: new — also triggers selection and calls \onSegmentKeyEnterDown\; \e.preventDefault()\ prevents page scroll.

## Tests added/updated

- Chart accessible name: default label, custom \riaLabel\ prop.
- Segment accessible label: default, custom \getSegmentAriaLabel\ factory.
- Keyboard activation: Space and Enter both fire \onSegmentKeyEnterDown\.
- Non-interactive behavior: gap segments have no role/aria-label/aria-pressed.
- TypeScript/pack smoke: \pack:smoke\ passes, TypeScript consumer compiles cleanly.
- \isKeyDownSpace\ utility: 6 unit tests.
- \Chart.spec.tsx\: updated fixture to include \getSegmentAriaLabel\.

## Local checks

- [x] \pnpm install\
- [x] \pnpm run check\
- [x] \pnpm run lint\
- [x] \pnpm run format:check\
- [x] \pnpm run type-check\
- [x] \pnpm run type-check:test\
- [x] \pnpm run build\
- [x] \pnpm run test\
- [x] \pnpm run test:cover\
- [x] \pnpm run pack:smoke\
- [x] \pnpm run size\
- [x] \pnpm run check:all\
- [x] \pnpm audit\

## Scope

Backward-compatible optional API only.
No CI restore.
No publish restore.
No npm publish.
No new runtime dependencies.
No \dist/\ committed.