### PR TITLE
ci: restore validation workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,30 +1,49 @@
-# Temporarily disabled during maintenance.
-# CI will be restored after pnpm/tooling/build/test modernization is complete.
-# See: docs/maintenance/01-pnpm-ci-pause.md
+# Validation-only CI. npm publish remains disabled until the release workflow is redesigned.
 name: CI
-on:
-  workflow_dispatch:
-jobs:
-  build:
-    name: Build and lint on Node ${{ matrix.node }} and ${{ matrix.os }}
 
-    runs-on: ${{ matrix.os }}
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Quality / Node ${{ matrix.node }}
+    runs-on: ubuntu-latest
+
     strategy:
+      fail-fast: false
       matrix:
-        node: ['14.x']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        node:
+          - 22
+          - 24
 
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v2
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
+          cache: pnpm
 
-      - name: Install deps and build (with cache)
-        uses: bahmutov/npm-install@v1
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
-      - name: Lint && Build
-        run: yarn build
+      - name: Run full local quality gate
+        run: pnpm run check:all
+
+      - name: Audit dependencies
+        run: pnpm audit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,10 @@ jobs:
       # ${NODE_AUTH_TOKEN} in .npmrc into `npm pack --json` stdout, which
       # would break the JSON.parse call in scripts/package-smoke-test.js.
       NODE_AUTH_TOKEN: ""
+      # Prevent Husky from running its prepare/init script during `npm pack
+      # --json` lifecycle hooks in CI, which would pollute stdout and break
+      # the JSON.parse call in scripts/package-smoke-test.js.
+      HUSKY: "0"
 
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,9 +24,12 @@ jobs:
       # ${NODE_AUTH_TOKEN} in .npmrc into `npm pack --json` stdout, which
       # would break the JSON.parse call in scripts/package-smoke-test.js.
       NODE_AUTH_TOKEN: ""
-      # Prevent Husky from running its prepare/init script during `npm pack
-      # --json` lifecycle hooks in CI, which would pollute stdout and break
-      # the JSON.parse call in scripts/package-smoke-test.js.
+      # Prevent Husky from printing to stdout when the prepare script runs
+      # during `npm pack --json` lifecycle hooks. Without this, Husky's
+      # skip-message pollutes stdout and breaks JSON.parse in package-smoke-test.js.
+      # Note: the actual --ignore-scripts fix is applied in package-smoke-test.js
+      # (passing --ignore-scripts directly to npm pack), which is the definitive
+      # fix. HUSKY=0 is kept as a defense-in-depth measure.
       HUSKY: "0"
 
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,12 @@ jobs:
     name: Quality / Node ${{ matrix.node }}
     runs-on: ubuntu-latest
 
+    env:
+      # Prevent npm 10 (Node 22) from printing a warning about the unset
+      # ${NODE_AUTH_TOKEN} in .npmrc into `npm pack --json` stdout, which
+      # would break the JSON.parse call in scripts/package-smoke-test.js.
+      NODE_AUTH_TOKEN: ""
+
     strategy:
       fail-fast: false
       matrix:

--- a/docs/maintenance/12-restore-ci.md
+++ b/docs/maintenance/12-restore-ci.md
@@ -1,0 +1,44 @@
+# Stage 12 — Restore CI
+
+## Summary
+
+- Restored validation-only GitHub Actions CI.
+- CI runs on pull requests and pushes to `master`.
+- CI uses pnpm and the canonical local `check:all` gate.
+- CI runs dependency audit.
+- Publish remains disabled/no-op.
+
+## CI behavior
+
+- Events: `pull_request` and `push` to `master` only (not all branches).
+- Node versions: 22 (LTS) and 24 (current development baseline), matrix strategy.
+- Package manager: pnpm via Corepack.
+- Commands: `pnpm install --frozen-lockfile`, `pnpm run check:all`, `pnpm audit`.
+- Permissions: `contents: read` only.
+- Concurrency: `cancel-in-progress: true` per workflow+ref group.
+
+## Publish safety
+
+- Publish workflow status: disabled/no-op (`workflow_dispatch` only, echoes a message).
+- NPM token usage: none in any workflow file.
+- Automatic publish on merge: no.
+- Automatic publish on tag/release: no.
+
+## Why this CI shape
+
+- Ubuntu only: Windows/macOS matrix skipped to preserve Actions minutes; Windows coverage already provided by local agent runs throughout the audit.
+- Node 22/24 matrix: Node 24 is the active dev baseline; Node 22 provides LTS compatibility signal.
+- `check:all` alignment with local development: CI runs exactly what the developer runs locally — no divergence between local and remote gate.
+- No release/publish in this PR: publish workflow redesign is deferred to a separate stage.
+
+## Local checks
+
+- `pnpm install`: passed.
+- `pnpm run check:all`: passed (60 suites, 197 tests, build + types + lint + coverage + smoke + size-limit).
+- `pnpm audit`: 0 vulnerabilities.
+
+## Known issues left for later PRs
+
+- Publish workflow remains no-op.
+- Release checklist remains for later.
+- npm publish/provenance/tag strategy remains for later.

--- a/scripts/package-smoke-test.js
+++ b/scripts/package-smoke-test.js
@@ -82,11 +82,17 @@ if (!fs.existsSync(distIndexJs)) {
 // 3 + 9a. npm pack, and verify the tarball's reported file list
 // ---------------------------------------------------------------------------
 log('Packing tarball with npm pack');
-// --ignore-scripts: dist/ is already built by an explicit step above; we don't
-// want npm pack's "prepare" lifecycle hook (husky install) writing extra,
-// non-JSON output to stdout, which would otherwise break the --json parsing.
+// --ignore-scripts: dist/ is already built above; the flag is a best-effort hint
+// to suppress lifecycle/Husky output before the --json payload, but npm 10 (Node 22)
+// still runs the package's own `prepare` script regardless.  To stay resilient we
+// also slice stdout from the first '[' so any leading text (e.g. Husky's skip-message)
+// is discarded before JSON.parse, keeping the script stable across npm versions.
 const packJsonRaw = run('npm', ['pack', '--json', '--ignore-scripts', '--pack-destination', TMP_DIR], ROOT);
-const packInfo = JSON.parse(packJsonRaw)[0];
+const jsonStart = packJsonRaw.indexOf('[');
+if (jsonStart === -1) {
+  fail('npm pack --json produced no parseable JSON array in stdout');
+}
+const packInfo = JSON.parse(packJsonRaw.slice(jsonStart))[0];
 const tarballPath = path.join(TMP_DIR, packInfo.filename);
 
 if (!fs.existsSync(tarballPath)) {


### PR DESCRIPTION
## Summary

- Restored validation-only GitHub Actions CI.
- CI runs on pull requests and pushes to `master`.
- CI runs the canonical `pnpm run check:all` local quality gate.
- CI runs `pnpm audit`.
- Publish remains disabled/no-op.

## CI behavior

- Events: `pull_request` and `push` to `master` only.
- Node versions: 22 (LTS) and 24 (current baseline), matrix strategy.
- Package manager: pnpm via Corepack.
- Commands: `pnpm install --frozen-lockfile`, `pnpm run check:all`, `pnpm audit`.
- Permissions: `contents: read`.
- Concurrency: `cancel-in-progress: true` per workflow+ref group.

## Publish safety

- Publish workflow status: `workflow_dispatch`-only no-op (unchanged).
- NPM token usage: none in any workflow file.
- Automatic publish on merge: no.
- Automatic publish on tag/release: no.

## Local checks

- [x] `pnpm install`
- [x] `pnpm run check:all`
- [x] `pnpm audit`

## Scope

CI restore only.
No runtime code changes.
No dependency changes.
No publish restore.
No npm publish.
No `dist/` committed.

## CI follow-up fixes

Node 22 initially exposed npm 10 stdout behavior around `npm pack --json`:

1. `${NODE_AUTH_TOKEN}` warnings from `.npmrc` could pollute stdout, so CI now sets `NODE_AUTH_TOKEN: ""`.
2. Husky lifecycle output could also pollute stdout during `npm pack --json`. `--ignore-scripts` was added to the pack call as a best-effort measure, but npm 10 (Node 22) still runs the package's own `prepare` script regardless. The definitive fix is in `scripts/package-smoke-test.js`: the script now slices stdout from the first `[` before calling `JSON.parse`, discarding any leading lifecycle text and keeping parsing stable across npm versions.

Both Node 22 and Node 24 CI jobs now pass.
