### PR TITLE
ci: redesign manual publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,107 @@
-# Temporarily disabled during maintenance.
-# Automatic publish was wired to run after successful CI on master.
-# This workflow is now a no-op and will not publish the npm package under any trigger.
-# npm publish automation will be redesigned in a later maintenance PR after
-# tooling modernization (ESLint, Rollup, Node version, test stack) is complete.
-# See: docs/maintenance/01-pnpm-ci-pause.md
-name: Publish Disabled
+# Manual publish workflow for @garvae/react-pie-donut-chart.
+#
+# Trigger:        workflow_dispatch only (never on push or pull_request).
+# Default mode:   dry_run=true — safe by default, no actual publish.
+# Branch guard:   only runs when dispatched from master.
+# Quality gates:  install → check:all → audit → pack:smoke → version preflight.
+# Real publish:   dry_run=false, requires explicit manual dispatch by the owner.
+# NPM token:      secrets.NPM_TOKEN only (never hardcoded).
+# Provenance:     enabled on real publish (--provenance flag).
+#
+# To run a dry-run:
+#   GitHub Actions → Publish → Run workflow → dry_run=true (default)
+#
+# To publish for real:
+#   1. Ensure version is bumped in package.json and dist/package.json.
+#   2. Ensure CI is green on master.
+#   3. GitHub Actions → Publish → Run workflow → dry_run=false.
+
+name: Publish
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run publish checks without publishing (true = safe default)"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      npm_tag:
+        description: "npm dist-tag to publish under"
+        required: true
+        default: "latest"
+        type: choice
+        options:
+          - "latest"
+          - "next"
 
 permissions:
   contents: read
+  # id-token: write is required for npm provenance attestation.
+  # It is only needed on real publish (dry_run=false), but GitHub Actions
+  # does not support conditional permissions, so we declare it globally.
+  # The token is never used during dry-run because the publish step is skipped.
+  id-token: write
+
+concurrency:
+  group: publish-${{ github.ref }}
+  # Do NOT cancel in-progress publish runs — a mid-flight npm publish is dangerous.
+  cancel-in-progress: false
 
 jobs:
-  publish-disabled:
+  publish:
+    name: Publish package (${{ inputs.dry_run == 'true' && 'dry-run' || 'REAL PUBLISH' }})
     runs-on: ubuntu-latest
+
+    # Safety guard: only allow dispatch from master.
+    if: github.ref == 'refs/heads/master'
+
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
     steps:
-      - run: echo "npm publish is temporarily disabled during maintenance. See docs/maintenance/01-pnpm-ci-pause.md"
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          # registry-url is required for NODE_AUTH_TOKEN to be picked up by npm publish.
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run full quality gate
+        run: pnpm run check:all
+
+      - name: Audit dependencies
+        run: pnpm audit
+
+      - name: Pack smoke test
+        run: pnpm run pack:smoke
+
+      - name: Verify package version is not already published
+        run: node scripts/verify-npm-version-not-published.js
+
+      # ---------------------------------------------------------------------------
+      # Dry-run: inspect what would be published without touching npm registry.
+      # ---------------------------------------------------------------------------
+      - name: Dry-run publish (inspect tarball contents)
+        if: inputs.dry_run == 'true'
+        run: npm publish ./dist --dry-run --access public --tag ${{ inputs.npm_tag }}
+
+      # ---------------------------------------------------------------------------
+      # Real publish: only when dry_run is explicitly set to false by the owner.
+      # ---------------------------------------------------------------------------
+      - name: Publish to npm
+        if: inputs.dry_run == 'false'
+        run: npm publish ./dist --provenance --access public --tag ${{ inputs.npm_tag }}

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ performance refactor, and added ARIA roles and keyboard accessibility semantics.
 The public API is intentionally kept backward-compatible. New functionality is added
 through optional props only.
 
-> **CI is currently disabled during maintenance. Publish automation is currently no-op.
-> Local quality gates run on every change.**
+> **CI runs on every PR and push to `master`. Publish automation is manual-only —
+> see [`docs/release-checklist.md`](docs/release-checklist.md).**
 
 ---
 
@@ -320,9 +320,13 @@ The local quality gate (`pnpm run check:all`) covers:
 
 ## Release / publishing
 
-Publish automation is intentionally disabled during this maintenance period. Releases are
-prepared and published manually after all local quality gates pass. Each maintenance stage
-is documented in `docs/maintenance/`.
+Publishing is always manual. The publish workflow is triggered via GitHub Actions
+(`workflow_dispatch`) and runs in dry-run mode by default — no publish happens until
+the owner explicitly sets `dry_run=false`.
+
+See [`docs/release-checklist.md`](docs/release-checklist.md) for the full step-by-step
+release guide and [`docs/maintenance/13-publish-workflow-redesign.md`](docs/maintenance/13-publish-workflow-redesign.md)
+for workflow design details.
 
 ---
 

--- a/docs/maintenance/13-publish-workflow-redesign.md
+++ b/docs/maintenance/13-publish-workflow-redesign.md
@@ -1,0 +1,70 @@
+# Stage 13 — Publish workflow redesign
+
+## Summary
+
+- Replaced the disabled no-op publish workflow with a manual `workflow_dispatch` publish workflow.
+- Added `dry_run=true` as the safe default — no publish happens unless explicitly changed.
+- Added `scripts/verify-npm-version-not-published.js` to block duplicate publishes.
+- Added `docs/release-checklist.md` with a practical step-by-step release guide.
+- Kept actual publishing fully manual and guarded behind explicit owner dispatch.
+- Did **not** publish the package in this PR.
+
+---
+
+## Publish workflow
+
+| Field | Value |
+|---|---|
+| File | `.github/workflows/publish.yml` |
+| Trigger | `workflow_dispatch` only |
+| Default mode | `dry_run=true` (safe — no publish) |
+| Required branch | `refs/heads/master` (enforced via `if:` guard) |
+| Node version | 24 |
+| Commands | `pnpm install --frozen-lockfile` → `pnpm run check:all` → `pnpm audit` → `pnpm run pack:smoke` → version preflight → publish |
+| NPM token source | `secrets.NPM_TOKEN` (GitHub secret, never hardcoded) |
+| Provenance | `--provenance` on real publish (`dry_run=false`) |
+| Dist-tag support | `latest` (default) or `next` |
+| Publish directory | `./dist` (mirrors `publish:dist` script: `cd dist && npm publish`) |
+
+---
+
+## Safety guards
+
+| Guard | Status |
+|---|---|
+| No publish on `pull_request` | ✅ `workflow_dispatch` only |
+| No publish on `push` to `master` | ✅ `workflow_dispatch` only |
+| Branch guard | ✅ `if: github.ref == 'refs/heads/master'` |
+| Version already published check | ✅ `scripts/verify-npm-version-not-published.js` exits 1 if duplicate |
+| `dry_run=true` default | ✅ Safe by default — runs all gates but skips actual publish |
+| `dry_run=false` manual only | ✅ Requires explicit owner action in GitHub Actions UI |
+| Package smoke test before publish | ✅ `pnpm run pack:smoke` runs in both dry-run and real publish |
+| No hardcoded npm token | ✅ `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` only |
+| Concurrency | ✅ `cancel-in-progress: false` — a mid-flight publish is never cancelled |
+
+---
+
+## Release checklist
+
+- File: `docs/release-checklist.md`
+- Main steps: pre-release checks → local build → dry-run workflow → real publish → post-release verification
+
+---
+
+## Local checks (results at time of PR)
+
+| Command | Result |
+|---|---|
+| `pnpm install` | ✅ pass |
+| `pnpm run check:all` | ✅ pass (197 tests, 0 failures; 37 biome warnings are pre-existing) |
+| `pnpm audit` | ✅ no known vulnerabilities |
+| `pnpm run pack:smoke` | ✅ pass |
+| `node scripts/verify-npm-version-not-published.js` | ✅ exits 0 — `1.0.3` is not yet published on the public npm registry. Safe to publish when ready. |
+
+---
+
+## Known issues left for later PRs
+
+- Actual version bump is a separate release PR decision for the owner.
+- GitHub Release automation (tagging, release notes) is optional future work.
+- The 37 biome warnings are pre-existing and tracked separately from this PR.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,44 @@
+# Release checklist
+
+## Before release
+
+- [ ] Merge all intended PRs into `master`.
+- [ ] Confirm CI is green on `master`.
+- [ ] Confirm `pnpm run check:all` passes locally.
+- [ ] Confirm `pnpm audit` is clean.
+- [ ] Confirm README examples match the public API.
+- [ ] Decide version bump: patch / minor / major.
+- [ ] Update `package.json` version field.
+- [ ] Update release notes / changelog draft.
+- [ ] Run `pnpm run build` to regenerate `dist/` (version in `dist/package.json` is updated by `postbuild`).
+- [ ] Run `pnpm run pack:smoke` to verify the tarball locally.
+- [ ] Check package contents with `npm pack --dry-run` or the publish workflow dry-run.
+- [ ] Confirm `dist/package.json` has the correct `name`, `version`, `main`, `module`, `typings`, and `publishConfig`.
+
+## Dry run
+
+- [ ] Run the GitHub Actions **Publish** workflow with `dry_run=true` (the default).
+- [ ] Confirm dry-run output shows the expected tarball contents.
+- [ ] Confirm the version preflight reports "not yet published".
+- [ ] Confirm the full quality gate passes inside the workflow.
+
+## Publish
+
+- [ ] Run the GitHub Actions **Publish** workflow with `dry_run=false`.
+- [ ] Use `npm_tag=latest` for a stable release or `npm_tag=next` for a prerelease.
+- [ ] Confirm the npm package page shows the new version.
+- [ ] Create a GitHub Release with release notes if desired.
+- [ ] Verify installation in a throwaway project:
+      `npm install @garvae/react-pie-donut-chart@<version>`
+
+## After release
+
+- [ ] Announce the release if applicable.
+- [ ] Update any linked documentation or demo sites.
+- [ ] Open next development cycle (version bump to `-next` or similar if using prereleases).
+
+---
+
+> Publishing is **always manual**.
+> See [`docs/maintenance/13-publish-workflow-redesign.md`](maintenance/13-publish-workflow-redesign.md)
+> for the full publish workflow design and safety guards.

--- a/scripts/verify-npm-version-not-published.js
+++ b/scripts/verify-npm-version-not-published.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * Preflight check: ensure the current package version is not already published on npm.
+ *
+ * Reads version metadata from dist/package.json (preferred) or root package.json.
+ * Exits with code 1 if the version already exists on npm, so the publish workflow
+ * fails loudly before attempting a duplicate publish.
+ * Exits with code 0 if the version is free (npm returns 404).
+ *
+ * Always queries the public npm registry directly (--registry flag) to bypass any
+ * local .npmrc overrides that redirect scoped packages to a private registry.
+ *
+ * Does NOT require an npm token — uses the public npm registry read API.
+ * Does NOT print secrets.
+ * Works on Windows (shell: true) and Linux/macOS.
+ *
+ * Usage:
+ *   node scripts/verify-npm-version-not-published.js
+ */
+
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// ---------------------------------------------------------------------------
+// Resolve package metadata
+// ---------------------------------------------------------------------------
+const root = path.resolve(__dirname, '..');
+const distPackageJsonPath = path.join(root, 'dist', 'package.json');
+const rootPackageJsonPath = path.join(root, 'package.json');
+
+let pkgPath;
+
+if (fs.existsSync(distPackageJsonPath)) {
+  pkgPath = distPackageJsonPath;
+  process.stdout.write(`[verify-version] Reading metadata from dist/package.json\n`);
+} else {
+  pkgPath = rootPackageJsonPath;
+  process.stdout.write(`[verify-version] dist/package.json not found, falling back to package.json\n`);
+}
+
+let pkg;
+
+try {
+  pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+} catch (err) {
+  process.stderr.write(`[verify-version] ERROR: Could not parse ${pkgPath}: ${err.message}\n`);
+  process.exit(1);
+}
+
+const { name, version } = pkg;
+
+if (!name || !version) {
+  process.stderr.write(`[verify-version] ERROR: "name" or "version" missing in ${pkgPath}\n`);
+  process.exit(1);
+}
+
+process.stdout.write(`[verify-version] Checking npm registry for ${name}@${version}\n`);
+
+// ---------------------------------------------------------------------------
+// Query the public npm registry directly.
+//
+// We pass --registry explicitly to bypass any .npmrc overrides that may redirect
+// scoped packages (e.g. @garvae/) to a private registry such as GitHub Packages.
+//
+// shell: true is required on Windows where `npm` resolves to npm.cmd.
+// ---------------------------------------------------------------------------
+const result = spawnSync(
+  'npm',
+  ['view', `${name}@${version}`, 'version', '--json', '--registry', 'https://registry.npmjs.org'],
+  {
+    encoding: 'utf8',
+    shell: true,
+    stdio: ['ignore', 'pipe', 'pipe']
+  }
+);
+
+// Spawn-level error (e.g. npm not found on PATH).
+if (result.error) {
+  process.stderr.write(`[verify-version] ERROR: Failed to spawn npm: ${result.error.message}\n`);
+  process.exit(1);
+}
+
+const stdout = (result.stdout || '').trim();
+const stderr = (result.stderr || '').trim();
+const combined = `${stdout}\n${stderr}`;
+
+// npm exits 0 and prints the version string (JSON) when it exists on the registry.
+if (result.status === 0 && stdout.length > 0) {
+  process.stderr.write(
+    `[verify-version] BLOCKED: ${name}@${version} is already published on npm.\n` +
+      `  Bump the version in package.json (and rebuild dist/) before publishing.\n`
+  );
+  process.exit(1);
+}
+
+// npm exits non-zero with E404 when the version does not exist.
+if (result.status !== 0) {
+  if (combined.includes('E404') || combined.includes('404')) {
+    process.stdout.write(`[verify-version] OK: ${name}@${version} is not yet published. Safe to publish.\n`);
+    process.exit(0);
+  }
+
+  // Unknown error from npm — surface it and fail safely.
+  process.stderr.write(`[verify-version] ERROR: Unexpected npm response (exit ${result.status}):\n${combined}\n`);
+  process.exit(result.status || 1);
+}
+
+// npm exited 0 but printed nothing — treat as version not found (safe to publish).
+process.stdout.write(`[verify-version] OK: ${name}@${version} — npm returned no output. Safe to publish.\n`);
+process.exit(0);


### PR DESCRIPTION
## Summary

- Replaced disabled publish workflow with a manual publish workflow.
- Added dry-run mode as the default.
- Added npm version preflight before publish.
- Added release checklist.
- Kept actual publishing manual and guarded.
- Did not publish the package.

## Publish workflow

- Trigger: `workflow_dispatch` only
- Default mode: `dry_run=true` (safe — no publish)
- Branch guard: `if: github.ref == 'refs/heads/master'`
- Node version: 24
- Quality gates: `pnpm install` → `check:all` → `audit` → `pack:smoke` → version preflight
- Version preflight: `scripts/verify-npm-version-not-published.js` — exits 1 if already published
- Dry-run: `npm publish ./dist --dry-run` (default)
- Real publish: `npm publish ./dist --provenance --access public` (dry_run=false only)
- Provenance: `--provenance` on real publish
- Dist-tag: `latest` (default) or `next`

## Safety

- No publish on PR.
- No publish on push to `master`.
- No hardcoded npm token.
- `dry_run=true` by default.
- `dry_run=false` requires manual workflow dispatch.
- Version must not already exist on npm.

## Local checks

- [x] `pnpm install`
- [x] `pnpm run check:all`
- [x] `pnpm audit`
- [x] `pnpm run pack:smoke`
- [x] `node scripts/verify-npm-version-not-published.js` — exits 0, `1.0.3` is not yet published on the public npm registry.

## Scope

Publish workflow/docs/scripts only.
No runtime code changes.
No dependency changes.
No version bump.
No npm publish.
No `dist/` committed.
