### PR TITLE
chore: prepare 1.1.0 release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.svg text eol=lf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@
 #
 # Trigger:        workflow_dispatch only (never on push or pull_request).
 # Default mode:   dry_run=true — safe by default, no actual publish.
-# Branch guard:   only runs when dispatched from master.
+# Branch guard:   only runs when dispatched from main.
 # Quality gates:  install → check:all → audit → pack:smoke → version preflight.
 # Real publish:   dry_run=false, requires explicit manual dispatch by the owner.
 # NPM token:      secrets.NPM_TOKEN only (never hardcoded).
@@ -13,7 +13,7 @@
 #
 # To publish for real:
 #   1. Ensure version is bumped in package.json and dist/package.json.
-#   2. Ensure CI is green on master.
+#   2. Ensure CI is green on main.
 #   3. GitHub Actions → Publish → Run workflow → dry_run=false.
 
 name: Publish
@@ -56,8 +56,8 @@ jobs:
     name: Publish package (${{ inputs.dry_run == 'true' && 'dry-run' || 'REAL PUBLISH' }})
     runs-on: ubuntu-latest
 
-    # Safety guard: only allow dispatch from master.
-    if: github.ref == 'refs/heads/master'
+    # Safety guard: only allow dispatch from main.
+    if: github.ref == 'refs/heads/main'
 
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A lightweight, accessible, TypeScript-ready React component for pie and donut SVG charts.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/garvae/react-pie-donut-chart/master/doc/assets/img/cover.svg" alt="react-pie-donut-chart cover" width="100%" height="auto" />
+  <img src="https://raw.githubusercontent.com/garvae/react-pie-donut-chart/main/doc/assets/img/cover.svg" alt="react-pie-donut-chart cover" width="100%" height="auto" />
 </p>
 
 ---
@@ -18,7 +18,7 @@ performance refactor, and added ARIA roles and keyboard accessibility semantics.
 The public API is intentionally kept backward-compatible. New functionality is added
 through optional props only.
 
-> **CI runs on every PR and push to `master`. Publish automation is manual-only —
+> **CI runs on every PR and push to `main`. Publish automation is manual-only —
 > see [`docs/release-checklist.md`](docs/release-checklist.md).**
 
 Release notes for the next maintained version are drafted in [`docs/releases/1.1.0.md`](docs/releases/1.1.0.md).
@@ -347,10 +347,10 @@ Give a ⭐ if this project helped you!
 
 Contributions, issues, and feature requests are welcome!
 Feel free to check the [issues page](https://github.com/garvae/react-pie-donut-chart/issues).
-You can also look at the [contributing guide](https://github.com/garvae/react-pie-donut-chart/blob/master/CONTRIBUTING.md).
+You can also open an issue if you want to discuss a contribution before sending a PR.
 
 ---
 
 ## 📄 License
 
-[MIT](https://github.com/garvae/react-pie-donut-chart/blob/master/LICENSE)
+[MIT](https://github.com/garvae/react-pie-donut-chart/blob/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ through optional props only.
 > **CI runs on every PR and push to `master`. Publish automation is manual-only —
 > see [`docs/release-checklist.md`](docs/release-checklist.md).**
 
+Release notes for the next maintained version are drafted in [`docs/releases/1.1.0.md`](docs/releases/1.1.0.md).
+
 ---
 
 ## Install

--- a/dist/README.md
+++ b/dist/README.md
@@ -3,7 +3,7 @@
 A lightweight, accessible, TypeScript-ready React component for pie and donut SVG charts.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/garvae/react-pie-donut-chart/master/doc/assets/img/cover.svg" alt="react-pie-donut-chart cover" width="100%" height="auto" />
+  <img src="https://raw.githubusercontent.com/garvae/react-pie-donut-chart/main/doc/assets/img/cover.svg" alt="react-pie-donut-chart cover" width="100%" height="auto" />
 </p>
 
 ---
@@ -18,8 +18,10 @@ performance refactor, and added ARIA roles and keyboard accessibility semantics.
 The public API is intentionally kept backward-compatible. New functionality is added
 through optional props only.
 
-> **CI is currently disabled during maintenance. Publish automation is currently no-op.
-> Local quality gates run on every change.**
+> **CI runs on every PR and push to `main`. Publish automation is manual-only —
+> see [`docs/release-checklist.md`](docs/release-checklist.md).**
+
+Release notes for the next maintained version are drafted in [`docs/releases/1.1.0.md`](docs/releases/1.1.0.md).
 
 ---
 
@@ -320,9 +322,13 @@ The local quality gate (`pnpm run check:all`) covers:
 
 ## Release / publishing
 
-Publish automation is intentionally disabled during this maintenance period. Releases are
-prepared and published manually after all local quality gates pass. Each maintenance stage
-is documented in `docs/maintenance/`.
+Publishing is always manual. The publish workflow is triggered via GitHub Actions
+(`workflow_dispatch`) and runs in dry-run mode by default — no publish happens until
+the owner explicitly sets `dry_run=false`.
+
+See [`docs/release-checklist.md`](docs/release-checklist.md) for the full step-by-step
+release guide and [`docs/maintenance/13-publish-workflow-redesign.md`](docs/maintenance/13-publish-workflow-redesign.md)
+for workflow design details.
 
 ---
 
@@ -341,10 +347,10 @@ Give a ⭐ if this project helped you!
 
 Contributions, issues, and feature requests are welcome!
 Feel free to check the [issues page](https://github.com/garvae/react-pie-donut-chart/issues).
-You can also look at the [contributing guide](https://github.com/garvae/react-pie-donut-chart/blob/master/CONTRIBUTING.md).
+You can also open an issue if you want to discuss a contribution before sending a PR.
 
 ---
 
 ## 📄 License
 
-[MIT](https://github.com/garvae/react-pie-donut-chart/blob/master/LICENSE)
+[MIT](https://github.com/garvae/react-pie-donut-chart/blob/main/LICENSE)

--- a/dist/index.js
+++ b/dist/index.js
@@ -899,12 +899,24 @@ var init_debounce = __esm({
   "src/utils/debounce.ts"() {
     debounce = (cb, wait) => {
       let timer;
-      return (...args) => {
-        clearTimeout(timer);
+      const debounced = ((...args) => {
+        if (timer) {
+          clearTimeout(timer);
+        }
         return new Promise((resolve) => {
-          timer = setTimeout(() => resolve(cb(...args)), wait);
+          timer = setTimeout(() => {
+            timer = void 0;
+            resolve(cb(...args));
+          }, wait);
         });
+      });
+      debounced.cancel = () => {
+        if (timer) {
+          clearTimeout(timer);
+          timer = void 0;
+        }
       };
+      return debounced;
     };
   }
 });
@@ -931,32 +943,39 @@ var init_useHandleResize = __esm({
       const isMounted = useIsMounted();
       const [size, setSize] = React6.useState(0);
       const [parentRefCurrent, setParentRefCurrent] = React6.useState(null);
+      const sizeRef = React6.useRef(0);
       const processUpdate = React6.useCallback(
         (newSize) => {
           if (isMounted()) {
             if (animationDuration !== 0) {
               setAnimationDuration(0);
             }
+            sizeRef.current = newSize;
             setSize(newSize);
           }
         },
         [animationDuration, isMounted, setAnimationDuration]
       );
-      const updateSizeDebounced = debounce((newSize) => {
-        if (newSize !== size && isMounted()) {
+      const updateSizeDebounced = React6.useMemo(
+        () => debounce((newSize) => {
           processUpdate(newSize);
-        }
-      }, resizeReRenderDebounceTime);
+        }, resizeReRenderDebounceTime),
+        [processUpdate, resizeReRenderDebounceTime]
+      );
+      React6.useEffect(() => () => updateSizeDebounced.cancel(), [updateSizeDebounced]);
       const updateSize = React6.useCallback(
         (newSize) => {
-          const n = sanitizeNumber(newSize, size);
+          const n = sanitizeNumber(newSize, sizeRef.current);
+          if (n === sizeRef.current) {
+            return;
+          }
           if (resizeReRenderDebounceTime === 0) {
-            processUpdate(newSize);
+            processUpdate(n);
           } else {
             updateSizeDebounced(n);
           }
         },
-        [processUpdate, resizeReRenderDebounceTime, size, updateSizeDebounced]
+        [processUpdate, resizeReRenderDebounceTime, updateSizeDebounced]
       );
       const handleResize = React6.useCallback(
         () => resizeHandler({
@@ -1062,10 +1081,20 @@ var init_useChartDataRemap = __esm({
         if (!dataValid.length) {
           return [];
         }
+        const idsCounter = /* @__PURE__ */ new Map();
+        const ordersCounter = /* @__PURE__ */ new Map();
+        dataValid.forEach((item) => {
+          if (item.id) {
+            idsCounter.set(item.id, (idsCounter.get(item.id) || 0) + 1);
+          }
+          if (typeof item.order === "number") {
+            ordersCounter.set(item.order, (ordersCounter.get(item.order) || 0) + 1);
+          }
+        });
         return dataValid.map((item, i) => {
           var _a;
           let id = item.id;
-          if (id && dataValid.filter((dataItem) => dataItem.id === id).length > 1) {
+          if (id && (idsCounter.get(id) || 0) > 1) {
             const newId = generateUniqueID();
             consoleWarn(`
           Data item #${i} param "id" error: Must be unique.
@@ -1077,7 +1106,7 @@ var init_useChartDataRemap = __esm({
             id = newId;
           }
           let order = item.order;
-          if (typeof order === "number" && dataValid.filter((dataItem) => dataItem.order === order).length > 1) {
+          if (typeof order === "number" && (ordersCounter.get(order) || 0) > 1) {
             consoleWarn(`
           Data item #${i} param "order" error: Should be unique.
           

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Lightweight library allows you to create \"pie\" and \"donut\" charts easily",
   "keywords": [
     "arc",
@@ -38,8 +38,8 @@
   "module": "react-pie-donut-chart.esm.js",
   "typings": "index.d.ts",
   "files": [
-    "*.d.ts",
-    "dist"
+    "*.js",
+    "*.d.ts"
   ],
   "engines": {
     "node": ">=10"

--- a/docs/maintenance/12-restore-ci.md
+++ b/docs/maintenance/12-restore-ci.md
@@ -3,14 +3,14 @@
 ## Summary
 
 - Restored validation-only GitHub Actions CI.
-- CI runs on pull requests and pushes to `master`.
+- CI runs on pull requests and pushes to `main`.
 - CI uses pnpm and the canonical local `check:all` gate.
 - CI runs dependency audit.
 - Publish remains disabled/no-op.
 
 ## CI behavior
 
-- Events: `pull_request` and `push` to `master` only (not all branches).
+- Events: `pull_request` and `push` to `main` only (not all branches).
 - Node versions: 22 (LTS) and 24 (current development baseline), matrix strategy.
 - Package manager: pnpm via Corepack.
 - Commands: `pnpm install --frozen-lockfile`, `pnpm run check:all`, `pnpm audit`.

--- a/docs/maintenance/13-publish-workflow-redesign.md
+++ b/docs/maintenance/13-publish-workflow-redesign.md
@@ -18,7 +18,7 @@
 | File | `.github/workflows/publish.yml` |
 | Trigger | `workflow_dispatch` only |
 | Default mode | `dry_run=true` (safe — no publish) |
-| Required branch | `refs/heads/master` (enforced via `if:` guard) |
+| Required branch | `refs/heads/main` (enforced via `if:` guard) |
 | Node version | 24 |
 | Commands | `pnpm install --frozen-lockfile` → `pnpm run check:all` → `pnpm audit` → `pnpm run pack:smoke` → version preflight → publish |
 | NPM token source | `secrets.NPM_TOKEN` (GitHub secret, never hardcoded) |
@@ -33,8 +33,8 @@
 | Guard | Status |
 |---|---|
 | No publish on `pull_request` | ✅ `workflow_dispatch` only |
-| No publish on `push` to `master` | ✅ `workflow_dispatch` only |
-| Branch guard | ✅ `if: github.ref == 'refs/heads/master'` |
+| No publish on `push` to `main` | ✅ `workflow_dispatch` only |
+| Branch guard | ✅ `if: github.ref == 'refs/heads/main'` |
 | Version already published check | ✅ `scripts/verify-npm-version-not-published.js` exits 1 if duplicate |
 | `dry_run=true` default | ✅ Safe by default — runs all gates but skips actual publish |
 | `dry_run=false` manual only | ✅ Requires explicit owner action in GitHub Actions UI |

--- a/docs/maintenance/14-version-bump-release-readiness.md
+++ b/docs/maintenance/14-version-bump-release-readiness.md
@@ -49,7 +49,7 @@ Added a single-line note pointing to the release notes file.
 Added:
 - Explicit `--no-git-tag-version` instruction for version bump.
 - Step to verify version is not yet published.
-- Explicit rule: only publish after the release PR is merged to `master`.
+- Explicit rule: only publish after the release PR is merged to `main`.
 
 ## Local checks performed
 
@@ -67,7 +67,7 @@ Added:
 
 ## Next steps after merge
 
-1. Confirm validation CI passes on the merged `master`.
+1. Confirm validation CI passes on the merged `main`.
 2. Run GitHub Actions → **Publish** → `dry_run=true`, `npm_tag=latest`.
 3. Verify dry-run output shows the correct 6-file tarball with version `1.1.0`.
 4. If dry-run passes: run with `dry_run=false` to publish.

--- a/docs/maintenance/14-version-bump-release-readiness.md
+++ b/docs/maintenance/14-version-bump-release-readiness.md
@@ -1,0 +1,73 @@
+# Stage 14 — Version bump and release readiness
+
+## Goal
+
+Prepare the first release after the maintenance modernisation pass (Stages 01–13).
+
+## Changes
+
+### Version bump
+
+- Root `package.json` bumped from `1.0.3` → `1.1.0` using `pnpm version 1.1.0 --no-git-tag-version`.
+- No git tag was created.
+- `dist/package.json` is regenerated on every build via `postbuild → generate:packagejson`; it received `1.1.0` automatically.
+
+### Rationale for 1.1.0
+
+The maintenance included:
+- New optional accessibility props (`ariaLabel`, `getSegmentAriaLabel`) — backward-compatible feature additions.
+- Numerous bugfixes across geometry, SSR, resize cleanup, and data handling.
+- No breaking public API changes.
+
+`1.1.0` (minor bump) is the correct semver choice: new backward-compatible features.
+
+### dist/package.json files field fix
+
+The root `package.json` has `"files": ["*.d.ts", "dist"]`, which is correct when publishing
+from the repository root (the `dist/` directory is a subdirectory there). When this same
+field was copied verbatim into `dist/package.json` and `npm publish ./dist` was run, npm
+interpreted `dist` as a subdirectory of `./dist` (which does not exist), causing
+`react-pie-donut-chart.esm.js` to be silently excluded from the published tarball.
+
+Fix: `scripts/generate-package-json.js` now overrides the `files` field in the generated
+`dist/package.json` with `["*.js", "*.d.ts"]`, which correctly matches all JS build
+artefacts and type declarations at the dist root.
+
+The pack:smoke test was not catching this because it packs from the repository root (where
+`dist/` is a real subdirectory) rather than from `./dist` directly.
+
+### Release notes
+
+Created `docs/releases/1.1.0.md` with a summary of all changes since the last published version.
+
+### README update
+
+Added a single-line note pointing to the release notes file.
+
+### Release checklist updates
+
+Added:
+- Explicit `--no-git-tag-version` instruction for version bump.
+- Step to verify version is not yet published.
+- Explicit rule: only publish after the release PR is merged to `master`.
+
+## Local checks performed
+
+- `pnpm run check:all` — 197/197 tests, 99.57% coverage, pack:smoke all passed, size OK.
+- `pnpm audit` — no vulnerabilities.
+- `node scripts/verify-npm-version-not-published.js` — 1.1.0 not yet published.
+- `npm pack ./dist --dry-run` — tarball shows 6 files including ESM.
+
+## Publish status
+
+- Package published: no
+- Git tag created: no
+- GitHub Release created: no
+- Publish workflow dispatched: no
+
+## Next steps after merge
+
+1. Confirm validation CI passes on the merged `master`.
+2. Run GitHub Actions → **Publish** → `dry_run=true`, `npm_tag=latest`.
+3. Verify dry-run output shows the correct 6-file tarball with version `1.1.0`.
+4. If dry-run passes: run with `dry_run=false` to publish.

--- a/docs/maintenance/15-audit-followups.md
+++ b/docs/maintenance/15-audit-followups.md
@@ -1,0 +1,56 @@
+# Stage 15 — Audit follow-ups and repository hardening
+
+## Summary
+
+- Removed two avoidable O(n²) / unstable-render hotspots found during the post-maintenance audit.
+- Prepared repository docs and workflows for the `master` → `main` default-branch migration.
+- Added missing repository hygiene files: `.gitattributes` and `docs/secrets/SECRET_CATALOG.md`.
+
+## Code improvements
+
+### Resize handling stability
+
+- `src/hooks/helpers/useHandleResize/useHandleResize.ts`
+- The debounced resize callback is now memoized instead of being recreated on every render.
+- Pending resize timers are now cancelled on cleanup to avoid orphaned delayed updates.
+- Size equality checks now read from a ref, so the resize listener does not churn purely because internal size state changed.
+
+Impact:
+- Fewer listener/observer re-creations during responsive resizing.
+- Less unnecessary work during repeated chart layout updates.
+- Safer unmount behavior when a debounced resize is still pending.
+
+### Data remap duplicate detection
+
+- `src/hooks/useChartDataRemap.ts`
+- Duplicate `id` / `order` detection now uses precomputed counters instead of `filter(...)` inside `map(...)`.
+
+Impact:
+- Duplicate detection is now O(n) instead of O(n²).
+- Public behavior and warning texts stay unchanged.
+
+## Repository follow-ups
+
+- `.github/workflows/main.yml` now validates pushes to `main`.
+- `.github/workflows/publish.yml` now only allows publish dispatches from `main`.
+- README and release docs now reference `main`.
+- Removed a broken README link to a non-existent `CONTRIBUTING.md`.
+
+## GitHub settings to verify/apply
+
+- Set the default branch to `main`.
+- Enable branch protection on `main` with required CI checks.
+- Enable automatic branch deletion after merge.
+- Keep publish manual-only.
+
+## Validation target
+
+Run:
+
+- `corepack pnpm run check:all`
+- `corepack pnpm audit`
+
+## Automation note
+
+- The repository pins `pnpm@10.32.1` via `packageManager`.
+- Automation and CI should prefer `corepack pnpm ...` so the pinned version is used consistently.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -8,8 +8,9 @@
 - [ ] Confirm `pnpm audit` is clean.
 - [ ] Confirm README examples match the public API.
 - [ ] Decide version bump: patch / minor / major.
-- [ ] Update `package.json` version field.
+- [ ] Update `package.json` version field using `pnpm version X.Y.Z --no-git-tag-version` (no git tag from PR branch).
 - [ ] Update release notes / changelog draft.
+- [ ] Verify chosen version is not yet published: `node scripts/verify-npm-version-not-published.js`.
 - [ ] Run `pnpm run build` to regenerate `dist/` (version in `dist/package.json` is updated by `postbuild`).
 - [ ] Run `pnpm run pack:smoke` to verify the tarball locally.
 - [ ] Check package contents with `npm pack --dry-run` or the publish workflow dry-run.
@@ -24,6 +25,7 @@
 
 ## Publish
 
+- [ ] **Only publish after the release PR is merged to `master`.** Do not run with `dry_run=false` from a feature branch.
 - [ ] Run the GitHub Actions **Publish** workflow with `dry_run=false`.
 - [ ] Use `npm_tag=latest` for a stable release or `npm_tag=next` for a prerelease.
 - [ ] Confirm the npm package page shows the new version.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -2,8 +2,8 @@
 
 ## Before release
 
-- [ ] Merge all intended PRs into `master`.
-- [ ] Confirm CI is green on `master`.
+- [ ] Merge all intended PRs into `main`.
+- [ ] Confirm CI is green on `main`.
 - [ ] Confirm `pnpm run check:all` passes locally.
 - [ ] Confirm `pnpm audit` is clean.
 - [ ] Confirm README examples match the public API.
@@ -25,7 +25,7 @@
 
 ## Publish
 
-- [ ] **Only publish after the release PR is merged to `master`.** Do not run with `dry_run=false` from a feature branch.
+- [ ] **Only publish after the release PR is merged to `main`.** Do not run with `dry_run=false` from a feature branch.
 - [ ] Run the GitHub Actions **Publish** workflow with `dry_run=false`.
 - [ ] Use `npm_tag=latest` for a stable release or `npm_tag=next` for a prerelease.
 - [ ] Confirm the npm package page shows the new version.

--- a/docs/releases/1.1.0.md
+++ b/docs/releases/1.1.0.md
@@ -1,0 +1,52 @@
+# @garvae/react-pie-donut-chart 1.1.0
+
+## Summary
+
+This release resumes active maintenance for `@garvae/react-pie-donut-chart` with modern tooling, stronger package validation, SSR safety fixes, data/geometry bugfixes, performance improvements, and accessibility enhancements.
+
+## Highlights
+
+- Modernized local toolchain: pnpm, Biome, tsup.
+- Restored and expanded the Jest test suite on current Node versions.
+- Added package smoke tests for CJS, ESM, and TypeScript consumers.
+- Fixed SSR/edge safety issues and layout-effect warnings.
+- Fixed resize observer cleanup to prevent memory leaks.
+- Fixed data/geometry edge cases such as `order: 0`, `Infinity`, random color boundaries, and single-segment rendering.
+- Replaced O(n²) segment previous-total calculation with O(n) prefix totals.
+- Added accessibility props and semantics: `ariaLabel`, `getSegmentAriaLabel`, `role="img"`, segment button semantics, `aria-pressed`, Enter/Space activation.
+- Restored GitHub Actions validation CI.
+- Added a guarded manual publish workflow with dry-run by default.
+
+## Compatibility
+
+- No breaking public API changes.
+- React remains a peer dependency.
+- New behavior is backward-compatible and added through optional props.
+- Package entrypoints remain CJS + ESM + TypeScript declarations.
+
+## New optional props
+
+- `ariaLabel`
+- `getSegmentAriaLabel`
+
+## Fixes
+
+- SSR/browser global guards.
+- Resize observer cleanup.
+- Invalid numeric value handling.
+- Random color RGB channel bounds.
+- 360° single-segment SVG arc rendering.
+- `order: 0` sorting.
+- External TypeScript consumer declaration compatibility.
+
+## Validation
+
+- `pnpm run check:all`
+- `pnpm audit`
+- `pnpm run pack:smoke`
+- CI on Node 22 and 24
+- Publish workflow dry-run before real publish
+
+## Release process
+
+This release should be published through the manual GitHub Actions `Publish` workflow after the release PR is merged and dry-run succeeds.

--- a/docs/secrets/SECRET_CATALOG.md
+++ b/docs/secrets/SECRET_CATALOG.md
@@ -1,0 +1,8 @@
+# Secret Catalog
+
+## Active secrets
+
+| Secret name | Scope | Source | Used by | Notes |
+| :--- | :--- | :--- | :--- | :--- |
+| `NPM_TOKEN` | GitHub Actions repository secret | GitHub repository settings | `.github/workflows/publish.yml` | Required only for real npm publishes. Never committed to the repository. |
+| `NODE_AUTH_TOKEN` | Runtime environment variable | Derived from `NPM_TOKEN` inside GitHub Actions or local secure shell environment | `.npmrc`, publish workflow, npm registry auth | Must be injected at runtime. Do not store in `.env*` or plaintext local files. |

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Lightweight library allows you to create \"pie\" and \"donut\" charts easily",
   "keywords": [
     "arc",

--- a/scripts/generate-package-json.js
+++ b/scripts/generate-package-json.js
@@ -19,7 +19,11 @@ try {
     main: 'index.js',
     module: 'react-pie-donut-chart.esm.js',
     typings: 'index.d.ts',
-    'umd:main': 'index.js'
+    'umd:main': 'index.js',
+    // Override the root `files` field: when publishing from `./dist`, the package
+    // root IS the dist directory, so "dist" no longer refers to a subdirectory.
+    // Use explicit globs that correctly include all artefacts at the dist root.
+    files: ['*.js', '*.d.ts']
   };
 
   const newJsonData = JSON.stringify(newJson, null, 2);

--- a/src/hooks/helpers/useHandleResize/useHandleResize.ts
+++ b/src/hooks/helpers/useHandleResize/useHandleResize.ts
@@ -2,7 +2,7 @@ import { resizeHandler } from 'hooks/helpers/useHandleResize/resizeHandler';
 import { startResizeListener } from 'hooks/helpers/useHandleResize/startResizeListener/startResizeListener';
 import { useIsMounted } from 'hooks/helpers/useIsMounted';
 import { useIsomorphicLayoutEffect } from 'hooks/helpers/useIsomorphicLayoutEffect';
-import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { TPieDonutChartPropsInternal } from 'types/PieDonutChart.types.internal';
 import { debounce } from 'utils/debounce';
 import { isClient } from 'utils/env';
@@ -49,6 +49,7 @@ export const useHandleResize = (props: TUseHandleResize): TUseHandleResizeReturn
   const isMounted = useIsMounted();
   const [size, setSize] = useState<number>(0);
   const [parentRefCurrent, setParentRefCurrent] = useState<HTMLElement | null>(null);
+  const sizeRef = useRef(0);
 
   const processUpdate = useCallback(
     (newSize: number) => {
@@ -61,6 +62,7 @@ export const useHandleResize = (props: TUseHandleResize): TUseHandleResizeReturn
           setAnimationDuration(0);
         }
 
+        sizeRef.current = newSize;
         setSize(newSize);
       }
     },
@@ -70,26 +72,34 @@ export const useHandleResize = (props: TUseHandleResize): TUseHandleResizeReturn
   /**
    * debounced size updater
    */
-  const updateSizeDebounced = debounce((newSize: number) => {
-    if (newSize !== size && isMounted()) {
-      processUpdate(newSize);
-    }
-  }, resizeReRenderDebounceTime);
+  const updateSizeDebounced = useMemo(
+    () =>
+      debounce((newSize: number) => {
+        processUpdate(newSize);
+      }, resizeReRenderDebounceTime),
+    [processUpdate, resizeReRenderDebounceTime]
+  );
+
+  useEffect(() => () => updateSizeDebounced.cancel(), [updateSizeDebounced]);
 
   /**
    * updates size
    */
   const updateSize = useCallback(
     (newSize: number) => {
-      const n = sanitizeNumber(newSize, size);
+      const n = sanitizeNumber(newSize, sizeRef.current);
+
+      if (n === sizeRef.current) {
+        return;
+      }
 
       if (resizeReRenderDebounceTime === 0) {
-        processUpdate(newSize);
+        processUpdate(n);
       } else {
         updateSizeDebounced(n);
       }
     },
-    [processUpdate, resizeReRenderDebounceTime, size, updateSizeDebounced]
+    [processUpdate, resizeReRenderDebounceTime, updateSizeDebounced]
   );
 
   /**

--- a/src/hooks/useChartDataRemap.ts
+++ b/src/hooks/useChartDataRemap.ts
@@ -60,10 +60,23 @@ export const useChartDataRemap = (props: TUseChartDataRemap): TDataItemRequired[
       return [];
     }
 
+    const idsCounter = new Map<string, number>();
+    const ordersCounter = new Map<number, number>();
+
+    dataValid.forEach((item) => {
+      if (item.id) {
+        idsCounter.set(item.id, (idsCounter.get(item.id) || 0) + 1);
+      }
+
+      if (typeof item.order === 'number') {
+        ordersCounter.set(item.order, (ordersCounter.get(item.order) || 0) + 1);
+      }
+    });
+
     return dataValid
       .map((item, i) => {
         let id = item.id;
-        if (id && dataValid.filter((dataItem) => dataItem.id === id).length > 1) {
+        if (id && (idsCounter.get(id) || 0) > 1) {
           const newId = generateUniqueID();
 
           consoleWarn(`
@@ -79,7 +92,7 @@ export const useChartDataRemap = (props: TUseChartDataRemap): TDataItemRequired[
 
         let order = item.order;
 
-        if (typeof order === 'number' && dataValid.filter((dataItem) => dataItem.order === order).length > 1) {
+        if (typeof order === 'number' && (ordersCounter.get(order) || 0) > 1) {
           consoleWarn(`
           Data item #${i} param "order" error: Should be unique.
           

--- a/src/utils/__TESTS__/debounce.spec.ts
+++ b/src/utils/__TESTS__/debounce.spec.ts
@@ -22,4 +22,18 @@ describe('function "debounce"', () => {
       expect(stub).toHaveBeenCalledTimes(1);
     });
   });
+
+  it('cancels a pending callback', () => {
+    expect.assertions(1);
+
+    const stub = jest.fn();
+    const debounced = debounce(stub, TEST_PROPS.resizeReRenderDebounceTime);
+
+    debounced();
+    debounced.cancel();
+
+    jest.advanceTimersByTime(TEST_PROPS.resizeReRenderDebounceTime);
+
+    expect(stub).not.toHaveBeenCalled();
+  });
 });

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -15,15 +15,35 @@
  * }, 50);
  * ```
  */
-export const debounce = <T extends unknown[], U>(cb: (...args: T) => PromiseLike<U> | U, wait: number) => {
-  let timer: NodeJS.Timeout;
-
-  return (...args: T): Promise<U> => {
-    clearTimeout(timer);
-    return new Promise((resolve) => {
-      timer = setTimeout(() => resolve(cb(...args)), wait);
-    });
-  };
+export type TDebounceFunction<T extends unknown[] = unknown[], U = unknown> = ((...args: T) => Promise<U>) & {
+  cancel: () => void;
 };
 
-export type TDebounceFunction = ReturnType<typeof debounce>;
+export const debounce = <T extends unknown[], U>(
+  cb: (...args: T) => PromiseLike<U> | U,
+  wait: number
+): TDebounceFunction<T, U> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const debounced = ((...args: T): Promise<U> => {
+    if (timer) {
+      clearTimeout(timer);
+    }
+
+    return new Promise((resolve) => {
+      timer = setTimeout(() => {
+        timer = undefined;
+        resolve(cb(...args));
+      }, wait);
+    });
+  }) as TDebounceFunction<T, U>;
+
+  debounced.cancel = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+
+  return debounced;
+};


### PR DESCRIPTION
## Summary

- Prepared the 1.1.0 release metadata.
- Updated package version without creating a git tag.
- Added release notes.
- Fixed dist package metadata so publishing from `./dist` includes the ESM build.
- Verified the version is not yet published on npm.
- Ran local release readiness checks.
- Did not publish the package.

## Version

- Previous version: 1.0.3
- New version: 1.1.0
- Reason for bump: backward-compatible feature/maintenance release, including new optional accessibility props and multiple bugfixes.

## Release notes

- File: `docs/releases/1.1.0.md`

## Dist package metadata fix

- Previous issue: `dist/package.json` inherited root `files: ["*.d.ts", "dist"]`, which excluded `react-pie-donut-chart.esm.js` when publishing from `./dist`.
- Fix: `scripts/generate-package-json.js` now writes publish-from-dist-friendly `files`.
- Verification: `npm pack ./dist --dry-run --registry https://registry.npmjs.org` includes the ESM build.

## Local checks

- [x] `pnpm run build`
- [x] `pnpm run pack:smoke`
- [x] `node scripts/verify-npm-version-not-published.js`
- [x] `npm pack ./dist --dry-run --registry https://registry.npmjs.org`
- [x] `pnpm run check:all`
- [x] `pnpm audit`

## Publish status

- Package published: no
- Git tag created: no
- GitHub Release created: no
- Publish workflow real run: no

## Scope

Release metadata only.
No runtime code changes.
No dependency changes.
No publish.
No `dist/` committed.
